### PR TITLE
Rectify step in documentation of upsample.R

### DIFF
--- a/R/upsample.R
+++ b/R/upsample.R
@@ -88,11 +88,11 @@
 #'   labs(title = "Without upsample")
 #'
 #' recipe(class ~ ., data = circle_example) %>%
-#'   step_nearmiss(class) %>%
+#'   step_upsample(class) %>%
 #'   prep() %>%
 #'   juice() %>%
 #'   ggplot(aes(x, y, color = class)) +
-#'   geom_jitter() +
+#'   geom_jitter(width = 0.1, height = 0.1) +
 #'   labs(title = "With upsample (with jittering)")
 step_upsample <-
   function(recipe, ...,  over_ratio = 1, ratio = NA, role = NA, trained = FALSE,


### PR DESCRIPTION
The second example in the documentation included `step_nearmiss` instead of `step_upsample`. Also, in the same example, defining `width` and `heigth` in `geom_jitter` is necessary to actually see the up-sampled data points.