### PR TITLE
Correct typos in README Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -22,9 +22,9 @@ knitr::opts_chunk$set(
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 <!-- badges: end -->
 
-**themis** contain extra steps for the
+**themis** contains extra steps for the
 [`recipes`](https://CRAN.R-project.org/package=recipes) package for
-dealin gwith unbalanced data. The name **themis** is that of the [ancient Greek god](https://thishollowearth.wordpress.com/2012/07/02/god-of-the-week-themis/) who is typically  depicted with a balance.
+dealing with unbalanced data. The name **themis** is that of the [ancient Greek god](https://thishollowearth.wordpress.com/2012/07/02/god-of-the-week-themis/) who is typically  depicted with a balance.
 
 ![](https://thishollowearth.files.wordpress.com/2012/07/themis.jpg)
 


### PR DESCRIPTION
Related to #37 

The previous PR fixed the typo in the `.md` file only so this adds them to `README.Rmd`.