### PR TITLE
dont end with as_tibble() in bake functions

### DIFF
--- a/R/step_adasyn.R
+++ b/R/step_adasyn.R
@@ -188,7 +188,7 @@ bake.step_adasyn <- function(object, new_data, ...) {
   )
   new_data <- na_splice(new_data, synthetic_data, object)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_bsmote.R
+++ b/R/step_bsmote.R
@@ -222,7 +222,7 @@ bake.step_bsmote <- function(object, new_data, ...) {
   )
   new_data <- na_splice(new_data, synthetic_data, object)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_downsample.R
+++ b/R/step_downsample.R
@@ -221,7 +221,7 @@ bake.step_downsample <- function(object, new_data, ...) {
     }
   )
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_nearmiss.R
+++ b/R/step_nearmiss.R
@@ -201,7 +201,7 @@ bake.step_nearmiss <- function(object, new_data, ...) {
     }
   )
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_rose.R
+++ b/R/step_rose.R
@@ -222,7 +222,7 @@ bake.step_rose <- function(object, new_data, ...) {
   )
   new_data <- na_splice(new_data, synthetic_data, object)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_smote.R
+++ b/R/step_smote.R
@@ -195,7 +195,7 @@ bake.step_smote <- function(object, new_data, ...) {
   )
   new_data <- na_splice(new_data, synthetic_data, object)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_smotenc.R
+++ b/R/step_smotenc.R
@@ -179,7 +179,7 @@ bake.step_smotenc <- function(object, new_data, ...) {
   )
   new_data <- na_splice(new_data, synthetic_data, object)
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export

--- a/R/step_upsample.R
+++ b/R/step_upsample.R
@@ -217,7 +217,7 @@ bake.step_upsample <- function(object, new_data, ...) {
     }
   )
 
-  as_tibble(new_data)
+  new_data
 }
 
 #' @export


### PR DESCRIPTION
Since `bake.recipe()` calls `as_tibble()` after each step we don't need to do it inside each step.