### PR TITLE
Avoid error when upsampling without upsampling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # themis (development version)
 
+* Fixed bug where some upsampling functions would error if no upsampling was needed. (#119)
+
 # themis 1.0.0
 
 * Added case weights support for `step_upsample()` and `step_downsample()`

--- a/R/smote_impl.R
+++ b/R/smote_impl.R
@@ -91,7 +91,8 @@ smote_impl <- function(df, var, k, over_ratio, call = caller_env()) {
     synthetic <- smote_data(minority, k = k, n_samples = samples_needed[i])
     out_df <- as.data.frame(synthetic)
     names(out_df) <- setdiff(names(df), var)
-    out_df[var] <- data[[names(samples_needed)[i]]][[var]][1]
+    out_df_nrow <- min(nrow(out_df), 1)
+    out_df[var] <- data[[names(samples_needed)[i]]][[var]][out_df_nrow]
     out_df <- out_df[names(df)]
     out_dfs[[i]] <- out_df
   }

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -134,7 +134,9 @@ smotenc_data <- function(data, k, n_samples, smotenc_ids = seq_len(nrow(data))) 
   # Runs a nearest neighbor search
   # outputs a matrix, each row is a minority instance and each column is a nearest neighbor
   # k is +1 because the sample is always a nearest neighbor to itself
-  ids <- t(gower::gower_topn(x = data, y = data, n = k + 1)$index)
+  suppressWarnings(
+    ids <- t(gower::gower_topn(x = data, y = data, n = k + 1, )$index)
+  )
 
   # shuffles minority indicies and repeats that shuffling until the desired number of samples is reached
   indexes <- rep(sample(smotenc_ids), length.out = n_samples)

--- a/tests/testthat/test-smote_impl.R
+++ b/tests/testthat/test-smote_impl.R
@@ -69,3 +69,13 @@ test_that("ordering of columns shouldn't matter", {
     NA
   )
 })
+
+test_that("Doesn't error if no upsampling is done (#119)", {
+  dat <- data.frame(
+    outcome = c(rep("X", 101), rep("Z", 50)),
+    X1 = 1)
+
+  expect_no_error(
+    smote_impl(dat, "outcome", 5, over_ratio = 0.5)
+  )
+})

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -305,3 +305,13 @@ test_that("empty printing", {
 
   expect_snapshot(rec)
 })
+
+test_that("Doesn't error if no upsampling is done (#119)", {
+  dat <- data.frame(
+    outcome = c(rep("X", 101), rep("Z", 50)),
+    X1 = 1)
+
+  expect_no_error(
+    smotenc_impl(dat, "outcome", 5, over_ratio = 0.5)
+  )
+})

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -309,7 +309,8 @@ test_that("empty printing", {
 test_that("Doesn't error if no upsampling is done (#119)", {
   dat <- data.frame(
     outcome = c(rep("X", 101), rep("Z", 50)),
-    X1 = 1)
+    X1 = 1
+  )
 
   expect_no_error(
     smotenc_impl(dat, "outcome", 5, over_ratio = 0.5)


### PR DESCRIPTION
To close https://github.com/tidymodels/themis/issues/119

``` r
library(recipes)
#> Loading required package: dplyr
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stats':
#> 
#>     step
library(themis)
set.seed(123)

dat <- data.frame(
  outcome = c(rep("X", 101), rep("Z", 50)),
  X1 = 1)

rec_49 <- recipe(outcome ~ ., data = head(dat)) |>
  step_smote(outcome, over_ratio = 0.49, seed = 231)
rec_50 <- recipe(outcome ~ ., data = head(dat)) |>
  step_smote(outcome, over_ratio = 0.5, seed = 231)
rec_51 <- recipe(outcome ~ ., data = head(dat)) |>
  step_smote(outcome, over_ratio = 0.51, seed = 231)

prep(rec_49, dat)
#> Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          1
#> 
#> Training data contained 151 data points and no missing data.
#> 
#> Operations:
#> 
#> SMOTE based on outcome [trained]
prep(rec_51, dat)
#> Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          1
#> 
#> Training data contained 151 data points and no missing data.
#> 
#> Operations:
#> 
#> SMOTE based on outcome [trained]
prep(rec_50, dat)
#> Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          1
#> 
#> Training data contained 151 data points and no missing data.
#> 
#> Operations:
#> 
#> SMOTE based on outcome [trained]
```

<sup>Created on 2023-02-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>