### PR TITLE
move extract_parameter_set_dials to infrastructure section

### DIFF
--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -240,20 +240,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_adasyn(
-      all_predictors(),
-      over_ratio = hardhat::tune(),
-      neighbors = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -311,4 +297,19 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_adasyn(
+      all_predictors(),
+      over_ratio = hardhat::tune(),
+      neighbors = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -324,21 +324,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_bsmote(
-      all_predictors(),
-      over_ratio = hardhat::tune(),
-      neighbors = hardhat::tune(),
-      all_neighbors = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 3L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -396,4 +381,20 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_bsmote(
+      all_predictors(),
+      over_ratio = hardhat::tune(),
+      neighbors = hardhat::tune(),
+      all_neighbors = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 3L)
 })

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -226,19 +226,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_downsample(
-      all_predictors(),
-      under_ratio = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 1L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -296,4 +283,18 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_downsample(
+      all_predictors(),
+      under_ratio = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 1L)
 })

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -190,20 +190,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_nearmiss(
-      all_predictors(),
-      under_ratio = hardhat::tune(),
-      neighbors = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -261,4 +247,19 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_nearmiss(
+      all_predictors(),
+      under_ratio = hardhat::tune(),
+      neighbors = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -218,19 +218,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_rose(
-      all_predictors(),
-      over_ratio = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 1L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -288,4 +275,18 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_rose(
+      all_predictors(),
+      over_ratio = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 1L)
 })

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -236,20 +236,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_smote(
-      all_predictors(),
-      over_ratio = hardhat::tune(),
-      neighbors = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -307,4 +293,19 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_smote(
+      all_predictors(),
+      over_ratio = hardhat::tune(),
+      neighbors = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -255,20 +255,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_smotenc(
-      all_predictors(),
-      over_ratio = hardhat::tune(),
-      neighbors = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -326,4 +312,19 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_smotenc(
+      all_predictors(),
+      over_ratio = hardhat::tune(),
+      neighbors = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 2L)
 })

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -225,19 +225,6 @@ test_that("tunable", {
   )
 })
 
-test_that("tunable is setup to works with extract_parameter_set_dials works", {
-  rec <- recipe(~., data = mtcars) %>%
-    step_upsample(
-      all_predictors(),
-      over_ratio = hardhat::tune()
-    )
-
-  params <- extract_parameter_set_dials(rec)
-
-  expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 1L)
-})
-
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {
@@ -295,4 +282,18 @@ test_that("printing", {
 
   expect_snapshot(print(rec))
   expect_snapshot(prep(rec))
+})
+
+test_that("tunable is setup to works with extract_parameter_set_dials", {
+  skip_if_not_installed("dials")
+  rec <- recipe(~., data = mtcars) %>%
+    step_upsample(
+      all_predictors(),
+      over_ratio = hardhat::tune()
+    )
+
+  params <- extract_parameter_set_dials(rec)
+
+  expect_s3_class(params, "parameters")
+  expect_identical(nrow(params), 1L)
 })


### PR DESCRIPTION
ref: https://github.com/tidymodels/recipes/pull/1148

This PR aligns the title of the tests with {recipes} and adds missing `skip_if_not_installed("dials")`