### PR TITLE
Fix typos of over_ratio and under_ratio

### DIFF
--- a/R/downsample.R
+++ b/R/downsample.R
@@ -15,7 +15,7 @@
 #' @param column A character string of the variable name that will
 #'  be populated (eventually) by the `...` selectors.
 #' @param under_ratio A numeric value for the ratio of the
-#'  minority-to-majority frequencies. The default value (1) means
+#'  majority-to-minority frequencies. The default value (1) means
 #'  that all other levels are sampled down to have the same
 #'  frequency as the least occurring level. A value of 2 would mean
 #'  that the majority levels will have (at most) (approximately)

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -15,7 +15,7 @@
 #' @param column A character string of the variable name that will
 #'  be populated (eventually) by the `...` selectors.
 #' @param over_ratio A numeric value for the ratio of the
-#'  majority-to-minority frequencies. The default value (1) means
+#'  minority-to-majority frequencies. The default value (1) means
 #'  that all other levels are sampled up to have the same
 #'  frequency as the most occurring level. A value of 0.5 would mean
 #'  that the minority levels will have (at most) (approximately)

--- a/README.Rmd
+++ b/README.Rmd
@@ -86,7 +86,7 @@ example_data %>%
 
 ### Upsample / Over-sampling
 
-The following methods all share the tuning parameter `over_ratio`, which is the ratio of the majority-to-minority frequencies.
+The following methods all share the tuning parameter `over_ratio`, which is the ratio of the minority-to-majority frequencies.
 
 | name | function | Multi-class |
 |---|---|---|
@@ -123,7 +123,7 @@ recipe(~., example_data) %>%
 
 ### Downsample / Under-sampling
 
-Most of the the following methods all share the tuning parameter `under_ratio`, which is the ratio of the minority-to-majority frequencies.
+Most of the the following methods all share the tuning parameter `under_ratio`, which is the ratio of the majority-to-minority frequencies.
 
 | name | function | Multi-class | under_ratio |
 |---|---|---|---|


### PR DESCRIPTION
Fixes #143 and #110: majority-to-minority and minority-to-majority appear to be backwards. 

Does not change generated documentation like REAMDE.md and man .Rd files. I don't know how these are generated. 