### PR TITLE
More snapshots

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,8 +25,6 @@ jobs:
           - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
-          # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6'}
           # use 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: '4.1'}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ URL: https://github.com/tidymodels/themis, https://themis.tidymodels.org
 BugReports: https://github.com/tidymodels/themis/issues
 Depends: 
     R (>= 3.6),
-    recipes (>= 1.0.4)
+    recipes (>= 1.1.0.9000)
 Imports: 
     gower,
     lifecycle (>= 1.0.3),
@@ -41,6 +41,8 @@ Suggests:
     ggplot2,
     modeldata,
     testthat (>= 3.0.0)
+Remotes:
+    tidymodels/recipes
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/tests/testthat/_snaps/adasyn.md
+++ b/tests/testthat/_snaps/adasyn.md
@@ -44,6 +44,14 @@
       Caused by error in `prep()`:
       ! Cannot have any missing values. NAs found ind: Job.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_adasyn()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/bsmote.md
+++ b/tests/testthat/_snaps/bsmote.md
@@ -35,6 +35,14 @@
       Caused by error in `prep()`:
       ! Cannot have any missing values. NAs found ind: Job.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_bsmote()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/downsample.md
+++ b/tests/testthat/_snaps/downsample.md
@@ -63,6 +63,14 @@
       -- Operations 
       * Down-sampling based on: class | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_downsample()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/nearmiss.md
+++ b/tests/testthat/_snaps/nearmiss.md
@@ -35,6 +35,14 @@
       Caused by error in `prep()`:
       ! Cannot have any missing values. NAs found ind: Job.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_nearmiss()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/rose.md
+++ b/tests/testthat/_snaps/rose.md
@@ -34,6 +34,14 @@
       Caused by error in `prep()`:
       ! `x` must only have 2 levels.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_rose()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/smote.md
+++ b/tests/testthat/_snaps/smote.md
@@ -44,6 +44,14 @@
       Caused by error in `prep()`:
       ! Cannot have any missing values. NAs found ind: Job.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_smote()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/smotenc.md
+++ b/tests/testthat/_snaps/smotenc.md
@@ -1,3 +1,11 @@
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_smotenc()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/smotenc.md
+++ b/tests/testthat/_snaps/smotenc.md
@@ -1,3 +1,39 @@
+# errors if there isn't enough data
+
+    Code
+      recipe(Status ~ Age, data = credit_data0) %>% step_smotenc(Status) %>% prep()
+    Condition
+      Error in `step_smotenc()`:
+      Caused by error in `smotenc_impl()`:
+      ! Not enough observations of 'dummy' to perform SMOTE.
+
+# bad data
+
+    Code
+      rec %>% step_smotenc(x) %>% prep()
+    Condition
+      Error in `step_smotenc()`:
+      Caused by error in `prep()`:
+      ! `x` should be a factor variable.
+
+---
+
+    Code
+      rec %>% step_smotenc(class, id) %>% prep()
+    Condition
+      Error in `step_smotenc()`:
+      Caused by error in `prep()`:
+      ! The selector should select at most a single variable
+
+# NA in response
+
+    Code
+      recipe(Job ~ Age, data = credit_data) %>% step_smotenc(Job) %>% prep()
+    Condition
+      Error in `step_smotenc()`:
+      Caused by error in `prep()`:
+      ! Cannot have any missing values. NAs found ind: Job.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/tomek.md
+++ b/tests/testthat/_snaps/tomek.md
@@ -35,6 +35,14 @@
       Caused by error in `prep()`:
       ! Cannot have any missing values. NAs found ind: Status.
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_tomek()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/_snaps/upsample.md
+++ b/tests/testthat/_snaps/upsample.md
@@ -63,6 +63,14 @@
       -- Operations 
       * Up-sampling based on: class | Trained, ignored weights
 
+# bake method errors when needed non-standard role columns are missing
+
+    Code
+      bake(trained, new_data = circle_example[, -3])
+    Condition
+      Error in `step_upsample()`:
+      ! The following required column is missing from `new_data`: class.
+
 # empty printing
 
     Code

--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -250,8 +250,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3]),
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -129,11 +129,10 @@ test_that("ratio value works when oversampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_adasyn(Home),
-    NA
+      step_adasyn(Home)
   )
 })
 

--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -29,7 +29,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-adasyn_impl.R
+++ b/tests/testthat/test-adasyn_impl.R
@@ -1,7 +1,7 @@
 circle_example_num <- circle_example[, c("x", "y", "class")]
 
 test_that("adasyn() interfaces correctly", {
-  expect_error(adasyn(circle_example_num, var = "class"), NA)
+  expect_no_error(adasyn(circle_example_num, var = "class"))
 
   expect_snapshot(error = TRUE,
     adasyn(circle_example_num, var = "Class")

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -29,7 +29,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("basic usage", {
@@ -43,7 +43,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -334,8 +334,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -161,11 +161,10 @@ test_that("ratio value works when oversampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_bsmote(Home),
-    NA
+      step_bsmote(Home)
   )
 })
 

--- a/tests/testthat/test-bsmote_impl.R
+++ b/tests/testthat/test-bsmote_impl.R
@@ -1,7 +1,7 @@
 circle_example_num <- circle_example[, c("x", "y", "class")]
 
 test_that("bsmote() interfaces correctly", {
-  expect_error(bsmote(circle_example_num, var = "class"), NA)
+  expect_no_error(bsmote(circle_example_num, var = "class"))
 
   expect_snapshot(error = TRUE,
     bsmote(circle_example_num, var = "Class")

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -236,8 +236,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -99,11 +99,10 @@ test_that("ratio value works when undersampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_downsample(Home),
-    NA
+      step_downsample(Home)
   )
 })
 

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -23,7 +23,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -99,11 +99,10 @@ test_that("ratio value works when undersampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_nearmiss(Home),
-    NA
+      step_nearmiss(Home)
   )
 })
 

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -16,7 +16,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -200,8 +200,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -228,8 +228,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -25,25 +25,22 @@ test_that("minority_prop value", {
 })
 
 test_that("row matching works correctly #36", {
-  expect_error(
+  expect_no_error(
     recipe(class ~ ., data = circle_example) %>%
       step_rose(class, over_ratio = 1.2) %>%
-      prep(),
-    NA
+      prep()
   )
 
-  expect_error(
+  expect_no_error(
     recipe(class ~ ., data = circle_example) %>%
       step_rose(class, over_ratio = 0.8) %>%
-      prep(),
-    NA
+      prep()
   )
 
-  expect_error(
+  expect_no_error(
     recipe(class ~ ., data = circle_example) %>%
       step_rose(class, over_ratio = 1.7) %>%
-      prep(),
-    NA
+      prep()
   )
 })
 

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -58,7 +58,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -246,8 +246,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -129,11 +129,10 @@ test_that("ratio value works when oversampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_smote(Home),
-    NA
+      step_smote(Home)
   )
 })
 

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -29,7 +29,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-smote_impl.R
+++ b/tests/testthat/test-smote_impl.R
@@ -23,7 +23,7 @@ test_that("order doesn't matter", {
 test_that("smote() interfaces correctly", {
   circle_example_num <- circle_example[, 1:3]
 
-  expect_error(smote(circle_example_num, var = "class"), NA)
+  expect_no_error(smote(circle_example_num, var = "class"))
 
   expect_snapshot(error = TRUE,
     smote(circle_example_num, var = "Class")
@@ -64,9 +64,8 @@ test_that("ordering of columns shouldn't matter", {
     filter(!is.na(Job)) %>%
     select(Job, Time, Age, Expenses)
 
-  expect_error(
-    smote(credit_data0, "Job", over_ratio = 1),
-    NA
+  expect_no_error(
+    smote(credit_data0, "Job", over_ratio = 1)
   )
 })
 

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -33,7 +33,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -11,11 +11,11 @@ test_that("errors if there isn't enough data", {
   credit_data0$Status[1] <- "dummy"
   credit_data0$Status <- as.factor(credit_data0$Status)
 
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     recipe(Status ~ Age, data = credit_data0) %>%
       step_smotenc(Status) %>%
-      prep(),
-    "Not enough observations"
+      prep()
   )
 })
 
@@ -40,18 +40,18 @@ test_that("bad data", {
 
   rec <- recipe(~., data = circle_example)
   # numeric check
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     rec %>%
       step_smotenc(x) %>%
-      prep(),
-    regexp = "should be a factor variable."
+      prep()
   )
   # Multiple variable check
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     rec %>%
       step_smotenc(class, id) %>%
-      prep(),
-    regexp = "The selector should select at most a single variable"
+      prep()
   )
 })
 
@@ -62,22 +62,21 @@ test_that("allows for character variables", {
     stringsAsFactors = FALSE
   )
 
-  expect_error(
+  expect_no_error(
     recipe(~., data = df_char) %>%
       step_smotenc(x) %>%
-      prep(),
-    NA
+      prep()
   )
 })
 
 test_that("NA in response", {
   data(credit_data)
 
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     recipe(Job ~ Age, data = credit_data) %>%
       step_smotenc(Job) %>%
-      prep(),
-    regexp = "NAs found ind: Job."
+      prep()
   )
 })
 
@@ -140,11 +139,10 @@ test_that("ratio value works when oversampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_smotenc(Home),
-    NA
+      step_smotenc(Home)
   )
 })
 

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -265,8 +265,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-tomek.R
+++ b/tests/testthat/test-tomek.R
@@ -14,7 +14,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {

--- a/tests/testthat/test-tomek.R
+++ b/tests/testthat/test-tomek.R
@@ -146,8 +146,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-tomek_impl.R
+++ b/tests/testthat/test-tomek_impl.R
@@ -17,7 +17,7 @@ test_that("order doesn't matter", {
 test_that("tomek() interfaces correctly", {
   circle_example_num <- circle_example[, 1:3]
 
-  expect_error(tomek(circle_example_num, var = "class"), NA)
+  expect_no_error(tomek(circle_example_num, var = "class"))
 
   expect_snapshot(error = TRUE,
                   tomek(circle_example_num, var = "Class")
@@ -46,8 +46,7 @@ test_that("ordering of columns shouldn't matter", {
     filter(!is.na(Job)) %>%
     select(Job, Time, Age, Expenses)
 
-  expect_error(
-    tomek(credit_data0, "Job"),
-    NA
+  expect_no_error(
+    tomek(credit_data0, "Job")
   )
 })

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -99,11 +99,10 @@ test_that("ratio value works when oversampling", {
 
 test_that("allows multi-class", {
   data("credit_data")
-  expect_error(
+  expect_no_error(
     recipe(Home ~ Age + Income + Assets, data = credit_data) %>%
       step_impute_mean(Income, Assets) %>%
-      step_upsample(Home),
-    NA
+      step_upsample(Home)
   )
 })
 

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -235,8 +235,10 @@ test_that("bake method errors when needed non-standard role columns are missing"
 
   trained <- prep(rec, training = circle_example, verbose = FALSE)
 
-  expect_error(bake(trained, new_data = circle_example[, -3]),
-               class = "new_data_missing_column")
+  expect_snapshot(
+    error = TRUE,
+    bake(trained, new_data = circle_example[, -3])
+  )
 })
 
 test_that("empty printing", {

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -23,7 +23,7 @@ test_that("basic usage", {
 
   expect_equal(sort(te_xtab), sort(og_xtab))
 
-  expect_warning(prep(rec1), NA)
+  expect_no_warning(prep(rec1))
 })
 
 test_that("bad data", {


### PR DESCRIPTION
Ref: https://github.com/tidymodels/recipes/pull/1375

This PR:

- switched from `expect_warning()` and `expect_message()` to `expect_snapshot()`
- removed classed `expect_error()` and switched to `expect_snapshot(error = TRUE)`
- Switched from `expect_error(..., NA)` to `expect_no_error()`. Can't do `expect_no_condition()` due to dplyr_regroup signal
- Switched rest of `expect_error()` to `expect_snapshot(error = TRUE)`