### PR TITLE
Add times argument to enn() for Repeated Edited Nearest Neighbors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) was added. It cleans the data using the Edited Nearest Neighbors rule, removing observations whose class differs from the majority of their nearest neighbors (#115).
 
+* `step_enn()` (and its direct-implementation counterpart `enn()`) gain a `times` argument to apply the cleaning repeatedly, stopping early on convergence, which corresponds to Repeated Edited Nearest Neighbors (RENN) (#173).
+
 * `step_instance_hardness()` (and its direct-implementation counterpart `instance_hardness()`) was added. It under-samples the majority classes by removing the observations that are hardest to classify, estimated using the k-Disagreeing Neighbors measure (#172).
 
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).

--- a/R/enn.R
+++ b/R/enn.R
@@ -17,6 +17,10 @@
 #'  be populated (eventually) by the `...` selectors.
 #' @param neighbors An integer. Number of nearest neighbor that are used to
 #'  decide whether an observation is removed.
+#' @param times A positive integer for the maximum number of times ENN is
+#'  applied. Defaults to `1` for a single pass. Values greater than `1` repeat
+#'  the cleaning, stopping early once a pass removes no observations. Use
+#'  `Inf` to repeat until convergence (Repeated Edited Nearest Neighbors).
 #' @param seed An integer that will be used as the seed when
 #' applied.
 #' @return An updated version of `recipe` with the new step
@@ -30,6 +34,11 @@
 #' does not match the majority class among those neighbors, the observation is
 #' removed. This tends to remove noisy and borderline observations, which can
 #' lead to smoother decision boundaries.
+#'
+#' Setting `times` greater than 1 applies ENN repeatedly, removing more noisy
+#' and borderline observations on each pass and stopping early once a pass
+#' removes nothing. This corresponds to Repeated Edited Nearest Neighbors
+#' (RENN).
 #'
 #' All variables selected by `distance_with` must be numeric with no missing
 #' data.
@@ -62,6 +71,9 @@
 #' @references Wilson, D. L. (1972). Asymptotic properties of nearest neighbor
 #' rules using edited data. IEEE Transactions on Systems, Man, and Cybernetics,
 #' (3), 408-421.
+#'
+#' Tomek, I. (1976). An experiment with the edited nearest-neighbor rule. IEEE
+#' Transactions on Systems, Man, and Cybernetics, (6), 448-452.
 #'
 #' @seealso [enn()] for direct implementation
 #' @family Steps for under-sampling
@@ -123,6 +135,7 @@ step_enn <-
     column = NULL,
     neighbors = 3,
     distance = "euclidean",
+    times = 1,
     skip = TRUE,
     seed = sample.int(10^5, 1),
     distance_with = recipes::all_predictors(),
@@ -140,6 +153,7 @@ step_enn <-
         column = column,
         neighbors = neighbors,
         distance = distance,
+        times = times,
         predictors = NULL,
         skip = skip,
         seed = seed,
@@ -157,6 +171,7 @@ step_enn_new <-
     column,
     neighbors,
     distance,
+    times,
     predictors,
     skip,
     seed,
@@ -171,6 +186,7 @@ step_enn_new <-
       column = column,
       neighbors = neighbors,
       distance = distance,
+      times = times,
       predictors = predictors,
       skip = skip,
       seed = seed,
@@ -184,6 +200,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
   col_name <- recipes_eval_select(x$terms, training, info)
 
   check_number_whole(x$neighbors, arg = "neighbors", min = 1)
+  check_number_whole(x$times, arg = "times", min = 1, allow_infinite = TRUE)
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
@@ -207,6 +224,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
     column = col_name,
     neighbors = x$neighbors,
     distance = x$distance,
+    times = x$times,
     predictors = predictors,
     skip = x$skip,
     seed = x$seed,
@@ -239,7 +257,8 @@ bake.step_enn <- function(object, new_data, ...) {
         df = predictor_data,
         var = object$column,
         neighbors = object$neighbors,
-        distance = object$distance
+        distance = object$distance,
+        times = object$times
       )
     }
   )

--- a/R/enn_impl.R
+++ b/R/enn_impl.R
@@ -14,9 +14,17 @@
 #' @details
 #' All columns used in this function must be numeric with no missing data.
 #'
+#' Setting `times` greater than 1 applies ENN repeatedly. Each pass removes
+#' observations from the data before the next pass runs, stopping early once a
+#' pass removes nothing (convergence). This corresponds to Repeated Edited
+#' Nearest Neighbors (RENN). Use `times = Inf` to repeat until convergence.
+#'
 #' @references Wilson, D. L. (1972). Asymptotic properties of nearest neighbor
 #' rules using edited data. IEEE Transactions on Systems, Man, and Cybernetics,
 #' (3), 408-421.
+#'
+#' Tomek, I. (1976). An experiment with the edited nearest-neighbor rule. IEEE
+#' Transactions on Systems, Man, and Cybernetics, (6), 448-452.
 #'
 #' @seealso [step_enn()] for step function of this method
 #' @family Direct Implementations
@@ -29,18 +37,22 @@
 #' res <- enn(circle_numeric, var = "class", neighbors = 5)
 #'
 #' res <- enn(circle_numeric, var = "class", distance = "manhattan")
-enn <- function(df, var, neighbors = 3, distance = "euclidean") {
+#'
+#' # Repeated Edited Nearest Neighbors (RENN)
+#' res <- enn(circle_numeric, var = "class", times = Inf)
+enn <- function(df, var, neighbors = 3, distance = "euclidean", times = 1) {
   check_data_frame(df)
   check_var(var, df)
   check_number_whole(neighbors, min = 1)
   check_distance_arg(distance)
+  check_number_whole(times, min = 1, allow_infinite = TRUE)
 
   predictors <- setdiff(colnames(df), var)
 
   check_numeric(df[, predictors])
   check_na(select(df, -all_of(var)))
 
-  remove <- enn_impl(df, var, neighbors, distance)
+  remove <- enn_impl(df, var, neighbors, distance, times = times)
   if (length(remove) > 0) {
     df <- df[-remove, ]
   }
@@ -52,10 +64,9 @@ enn_impl <- function(
   var,
   neighbors = 3,
   distance = "euclidean",
+  times = 1,
   call = caller_env()
 ) {
-  outcome <- df[[var]]
-
   if (nrow(df) <= neighbors) {
     cli::cli_abort(
       c(
@@ -65,6 +76,35 @@ enn_impl <- function(
       call = call
     )
   }
+
+  # Row indices (into the original `df`) that are still active
+  active <- seq_len(nrow(df))
+  iter <- 0
+
+  while (iter < times) {
+    iter <- iter + 1
+
+    # Not enough observations left to keep cleaning
+    if (length(active) <= neighbors) {
+      break
+    }
+
+    remove <- enn_single(df[active, , drop = FALSE], var, neighbors, distance)
+
+    if (length(remove) == 0) {
+      break
+    }
+
+    active <- active[-remove]
+  }
+
+  setdiff(seq_len(nrow(df)), active)
+}
+
+# A single pass of Edited Nearest Neighbors. Returns the row indices of `df`
+# that should be removed.
+enn_single <- function(df, var, neighbors, distance) {
+  outcome <- df[[var]]
 
   idx <- nn_indices(as.matrix(df[names(df) != var]), k = neighbors, distance)
   # First column is the observation itself; drop it

--- a/man/enn.Rd
+++ b/man/enn.Rd
@@ -4,7 +4,7 @@
 \alias{enn}
 \title{Edited Nearest Neighbors}
 \usage{
-enn(df, var, neighbors = 3, distance = "euclidean")
+enn(df, var, neighbors = 3, distance = "euclidean", times = 1)
 }
 \arguments{
 \item{df}{data.frame or tibble. Must have 1 factor variable and remaining
@@ -22,6 +22,11 @@ nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosin
 the RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
 large datasets.}
+
+\item{times}{A positive integer for the maximum number of times ENN is
+applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat
+the cleaning, stopping early once a pass removes no observations. Use
+\code{Inf} to repeat until convergence (Repeated Edited Nearest Neighbors).}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.
@@ -32,6 +37,11 @@ neighbors.
 }
 \details{
 All columns used in this function must be numeric with no missing data.
+
+Setting \code{times} greater than 1 applies ENN repeatedly. Each pass removes
+observations from the data before the next pass runs, stopping early once a
+pass removes nothing (convergence). This corresponds to Repeated Edited
+Nearest Neighbors (RENN). Use \code{times = Inf} to repeat until convergence.
 }
 \examples{
 circle_numeric <- circle_example[, c("x", "y", "class")]
@@ -41,11 +51,17 @@ res <- enn(circle_numeric, var = "class")
 res <- enn(circle_numeric, var = "class", neighbors = 5)
 
 res <- enn(circle_numeric, var = "class", distance = "manhattan")
+
+# Repeated Edited Nearest Neighbors (RENN)
+res <- enn(circle_numeric, var = "class", times = Inf)
 }
 \references{
 Wilson, D. L. (1972). Asymptotic properties of nearest neighbor
 rules using edited data. IEEE Transactions on Systems, Man, and Cybernetics,
 (3), 408-421.
+
+Tomek, I. (1976). An experiment with the edited nearest-neighbor rule. IEEE
+Transactions on Systems, Man, and Cybernetics, (6), 448-452.
 }
 \seealso{
 \code{\link[=step_enn]{step_enn()}} for step function of this method

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -13,6 +13,7 @@ step_enn(
   column = NULL,
   neighbors = 3,
   distance = "euclidean",
+  times = 1,
   skip = TRUE,
   seed = sample.int(10^5, 1),
   distance_with = recipes::all_predictors(),
@@ -49,6 +50,11 @@ the RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
 large datasets.}
 
+\item{times}{A positive integer for the maximum number of times ENN is
+applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat
+the cleaning, stopping early once a pass removes no observations. Use
+\code{Inf} to repeat until convergence (Repeated Edited Nearest Neighbors).}
+
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some
 operations may not be able to be conducted on new data (e.g. processing the
@@ -82,6 +88,11 @@ finds the \code{neighbors} nearest neighbors and, if the class of the observatio
 does not match the majority class among those neighbors, the observation is
 removed. This tends to remove noisy and borderline observations, which can
 lead to smoother decision boundaries.
+
+Setting \code{times} greater than 1 applies ENN repeatedly, removing more noisy
+and borderline observations on each pass and stopping early once a pass
+removes nothing. This corresponds to Repeated Edited Nearest Neighbors
+(RENN).
 
 All variables selected by \code{distance_with} must be numeric with no missing
 data.
@@ -170,6 +181,9 @@ recipe(class ~ x + y, data = circle_example) |>
 Wilson, D. L. (1972). Asymptotic properties of nearest neighbor
 rules using edited data. IEEE Transactions on Systems, Man, and Cybernetics,
 (3), 408-421.
+
+Tomek, I. (1976). An experiment with the edited nearest-neighbor rule. IEEE
+Transactions on Systems, Man, and Cybernetics, (6), 448-452.
 }
 \seealso{
 \code{\link[=enn]{enn()}} for direct implementation

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -1,3 +1,14 @@
+# errors when not enough observations for neighbors
+
+    Code
+      bake(prep(step_enn(recipe(class ~ x + y, data = small), class, neighbors = 5,
+      skip = FALSE)), new_data = NULL)
+    Condition
+      Error in `step_enn()`:
+      Caused by error in `bake()`:
+      ! Not enough observations to compute 5 nearest neighbors.
+      i 3 observations were found, but 6 are needed.
+
 # bad data
 
     Code
@@ -72,6 +83,15 @@
       Error in `step_enn()`:
       Caused by error in `prep()`:
       ! `neighbors` must be a whole number larger than or equal to 1, not the number -1.
+
+---
+
+    Code
+      prep(step_enn(recipe(class ~ x + y, data = circle_example), class, times = -1))
+    Condition
+      Error in `step_enn()`:
+      Caused by error in `prep()`:
+      ! `times` must be a whole number larger than or equal to 1, not the number -1.
 
 # bake method errors when needed non-standard role columns are missing
 
@@ -150,15 +170,4 @@
       
       -- Operations 
       * ENN based on: class | Trained
-
-# errors when not enough observations for neighbors
-
-    Code
-      bake(prep(step_enn(recipe(class ~ x + y, data = small), class, neighbors = 5,
-      skip = FALSE)), new_data = NULL)
-    Condition
-      Error in `step_enn()`:
-      Caused by error in `bake()`:
-      ! Not enough observations to compute 5 nearest neighbors.
-      i 3 observations were found, but 6 are needed.
 

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -26,6 +26,38 @@ test_that("neighbors argument changes result", {
   expect_false(identical(nrow(baked1), nrow(baked3)))
 })
 
+test_that("times argument applies ENN repeatedly", {
+  set.seed(1)
+  n <- 200
+  noisy <- data.frame(
+    x = rnorm(n),
+    y = rnorm(n),
+    class = factor(sample(c("a", "b"), n, replace = TRUE))
+  )
+
+  n1 <- nrow(enn(noisy, var = "class", times = 1))
+  n2 <- nrow(enn(noisy, var = "class", times = 2))
+  n_inf <- nrow(enn(noisy, var = "class", times = Inf))
+
+  expect_lt(n2, n1)
+  expect_lte(n_inf, n2)
+})
+
+test_that("times converges before reaching the cap", {
+  set.seed(1)
+  n <- 200
+  noisy <- data.frame(
+    x = rnorm(n),
+    y = rnorm(n),
+    class = factor(sample(c("a", "b"), n, replace = TRUE))
+  )
+
+  expect_identical(
+    enn(noisy, var = "class", times = 100),
+    enn(noisy, var = "class", times = Inf)
+  )
+})
+
 test_that("errors when not enough observations for neighbors", {
   small <- circle_example[1:3, c("x", "y", "class")]
 
@@ -273,6 +305,12 @@ test_that("bad args", {
     error = TRUE,
     recipe(class ~ x + y, data = circle_example) |>
       step_enn(class, neighbors = -1) |>
+      prep()
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ x + y, data = circle_example) |>
+      step_enn(class, times = -1) |>
       prep()
   )
 })


### PR DESCRIPTION
Adds Repeated Edited Nearest Neighbor (RENN) support to `enn()` and `step_enn()` via a new `times` argument rather than a separate step, since RENN is just ENN applied iteratively. The default `times = 1` preserves the current single-pass behavior; higher values repeat the cleaning and stop early on convergence, and `times = Inf` repeats until convergence.

Closes #173.