### PR TITLE
Add all_k argument to enn() and step_enn() for All k-Nearest Neighbors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) gain a `times` argument to apply the cleaning repeatedly, stopping early on convergence, which corresponds to Repeated Edited Nearest Neighbors (RENN) (#173).
 
+* `step_enn()` (and its direct-implementation counterpart `enn()`) gain an `all_k` argument to apply the cleaning with an increasing number of neighbors, from 1 up to `neighbors`, which corresponds to All k-Nearest Neighbors (AllKNN) (#174).
+
 * `step_instance_hardness()` (and its direct-implementation counterpart `instance_hardness()`) was added. It under-samples the majority classes by removing the observations that are hardest to classify, estimated using the k-Disagreeing Neighbors measure (#172).
 
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).

--- a/R/enn.R
+++ b/R/enn.R
@@ -21,6 +21,10 @@
 #'  applied. Defaults to `1` for a single pass. Values greater than `1` repeat
 #'  the cleaning, stopping early once a pass removes no observations. Use
 #'  `Inf` to repeat until convergence (Repeated Edited Nearest Neighbors).
+#' @param all_k A logical. When `TRUE`, ENN is applied with an increasing number
+#'  of neighbors, from `1` up to `neighbors`, cleaning the data at each step
+#'  (All k-Nearest Neighbors). Takes precedence over `times`. Defaults to
+#'  `FALSE`.
 #' @param seed An integer that will be used as the seed when
 #' applied.
 #' @return An updated version of `recipe` with the new step
@@ -39,6 +43,10 @@
 #' and borderline observations on each pass and stopping early once a pass
 #' removes nothing. This corresponds to Repeated Edited Nearest Neighbors
 #' (RENN).
+#'
+#' Setting `all_k = TRUE` applies ENN with increasing numbers of neighbors, from
+#' `1` up to `neighbors`, cleaning the data at each step. This corresponds to
+#' All k-Nearest Neighbors (AllKNN) and takes precedence over `times`.
 #'
 #' All variables selected by `distance_with` must be numeric with no missing
 #' data.
@@ -136,6 +144,7 @@ step_enn <-
     neighbors = 3,
     distance = "euclidean",
     times = 1,
+    all_k = FALSE,
     skip = TRUE,
     seed = sample.int(10^5, 1),
     distance_with = recipes::all_predictors(),
@@ -143,6 +152,7 @@ step_enn <-
   ) {
     check_number_whole(seed)
     check_distance_arg(distance)
+    check_bool(all_k)
 
     add_step(
       recipe,
@@ -154,6 +164,7 @@ step_enn <-
         neighbors = neighbors,
         distance = distance,
         times = times,
+        all_k = all_k,
         predictors = NULL,
         skip = skip,
         seed = seed,
@@ -172,6 +183,7 @@ step_enn_new <-
     neighbors,
     distance,
     times,
+    all_k,
     predictors,
     skip,
     seed,
@@ -187,6 +199,7 @@ step_enn_new <-
       neighbors = neighbors,
       distance = distance,
       times = times,
+      all_k = all_k,
       predictors = predictors,
       skip = skip,
       seed = seed,
@@ -201,6 +214,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
 
   check_number_whole(x$neighbors, arg = "neighbors", min = 1)
   check_number_whole(x$times, arg = "times", min = 1, allow_infinite = TRUE)
+  warn_times_all_k(x$times, x$all_k)
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
@@ -225,6 +239,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
     neighbors = x$neighbors,
     distance = x$distance,
     times = x$times,
+    all_k = x$all_k,
     predictors = predictors,
     skip = x$skip,
     seed = x$seed,
@@ -258,7 +273,8 @@ bake.step_enn <- function(object, new_data, ...) {
         var = object$column,
         neighbors = object$neighbors,
         distance = object$distance,
-        times = object$times
+        times = object$times,
+        all_k = object$all_k
       )
     }
   )

--- a/R/enn_impl.R
+++ b/R/enn_impl.R
@@ -19,6 +19,10 @@
 #' pass removes nothing (convergence). This corresponds to Repeated Edited
 #' Nearest Neighbors (RENN). Use `times = Inf` to repeat until convergence.
 #'
+#' Setting `all_k = TRUE` applies ENN with increasing numbers of neighbors, from
+#' `1` up to `neighbors`, cleaning the data at each step. This corresponds to
+#' All k-Nearest Neighbors (AllKNN) and takes precedence over `times`.
+#'
 #' @references Wilson, D. L. (1972). Asymptotic properties of nearest neighbor
 #' rules using edited data. IEEE Transactions on Systems, Man, and Cybernetics,
 #' (3), 408-421.
@@ -40,19 +44,31 @@
 #'
 #' # Repeated Edited Nearest Neighbors (RENN)
 #' res <- enn(circle_numeric, var = "class", times = Inf)
-enn <- function(df, var, neighbors = 3, distance = "euclidean", times = 1) {
+#'
+#' # All k-Nearest Neighbors (AllKNN)
+#' res <- enn(circle_numeric, var = "class", all_k = TRUE)
+enn <- function(
+  df,
+  var,
+  neighbors = 3,
+  distance = "euclidean",
+  times = 1,
+  all_k = FALSE
+) {
   check_data_frame(df)
   check_var(var, df)
   check_number_whole(neighbors, min = 1)
   check_distance_arg(distance)
   check_number_whole(times, min = 1, allow_infinite = TRUE)
+  check_bool(all_k)
+  warn_times_all_k(times, all_k)
 
   predictors <- setdiff(colnames(df), var)
 
   check_numeric(df[, predictors])
   check_na(select(df, -all_of(var)))
 
-  remove <- enn_impl(df, var, neighbors, distance, times = times)
+  remove <- enn_impl(df, var, neighbors, distance, times = times, all_k = all_k)
   if (length(remove) > 0) {
     df <- df[-remove, ]
   }
@@ -65,6 +81,7 @@ enn_impl <- function(
   neighbors = 3,
   distance = "euclidean",
   times = 1,
+  all_k = FALSE,
   call = caller_env()
 ) {
   if (nrow(df) <= neighbors) {
@@ -77,28 +94,47 @@ enn_impl <- function(
     )
   }
 
+  # Number of neighbors to use on each pass. AllKNN increases k from 1 up to
+  # `neighbors`; RENN repeats with a fixed k up to `times` passes.
+  if (all_k) {
+    ks <- seq_len(neighbors)
+  } else {
+    ks <- rep(neighbors, min(times, nrow(df)))
+  }
+
   # Row indices (into the original `df`) that are still active
   active <- seq_len(nrow(df))
-  iter <- 0
 
-  while (iter < times) {
-    iter <- iter + 1
-
+  for (k in ks) {
     # Not enough observations left to keep cleaning
-    if (length(active) <= neighbors) {
+    if (length(active) <= k) {
       break
     }
 
-    remove <- enn_single(df[active, , drop = FALSE], var, neighbors, distance)
+    remove <- enn_single(df[active, , drop = FALSE], var, k, distance)
 
     if (length(remove) == 0) {
-      break
+      # RENN stops early at convergence; AllKNN continues with a larger k
+      if (!all_k) {
+        break
+      }
+      next
     }
 
     active <- active[-remove]
   }
 
   setdiff(seq_len(nrow(df)), active)
+}
+
+# Warn when both `times` and `all_k` are set, since `all_k` takes precedence.
+warn_times_all_k <- function(times, all_k, call = caller_env()) {
+  if (all_k && times != 1) {
+    cli::cli_warn(
+      "{.arg times} is ignored when {.arg all_k} is {.code TRUE}.",
+      call = call
+    )
+  }
 }
 
 # A single pass of Edited Nearest Neighbors. Returns the row indices of `df`

--- a/man/enn.Rd
+++ b/man/enn.Rd
@@ -4,7 +4,7 @@
 \alias{enn}
 \title{Edited Nearest Neighbors}
 \usage{
-enn(df, var, neighbors = 3, distance = "euclidean", times = 1)
+enn(df, var, neighbors = 3, distance = "euclidean", times = 1, all_k = FALSE)
 }
 \arguments{
 \item{df}{data.frame or tibble. Must have 1 factor variable and remaining
@@ -27,6 +27,11 @@ large datasets.}
 applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat
 the cleaning, stopping early once a pass removes no observations. Use
 \code{Inf} to repeat until convergence (Repeated Edited Nearest Neighbors).}
+
+\item{all_k}{A logical. When \code{TRUE}, ENN is applied with an increasing number
+of neighbors, from \code{1} up to \code{neighbors}, cleaning the data at each step
+(All k-Nearest Neighbors). Takes precedence over \code{times}. Defaults to
+\code{FALSE}.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.
@@ -42,6 +47,10 @@ Setting \code{times} greater than 1 applies ENN repeatedly. Each pass removes
 observations from the data before the next pass runs, stopping early once a
 pass removes nothing (convergence). This corresponds to Repeated Edited
 Nearest Neighbors (RENN). Use \code{times = Inf} to repeat until convergence.
+
+Setting \code{all_k = TRUE} applies ENN with increasing numbers of neighbors, from
+\code{1} up to \code{neighbors}, cleaning the data at each step. This corresponds to
+All k-Nearest Neighbors (AllKNN) and takes precedence over \code{times}.
 }
 \examples{
 circle_numeric <- circle_example[, c("x", "y", "class")]
@@ -54,6 +63,9 @@ res <- enn(circle_numeric, var = "class", distance = "manhattan")
 
 # Repeated Edited Nearest Neighbors (RENN)
 res <- enn(circle_numeric, var = "class", times = Inf)
+
+# All k-Nearest Neighbors (AllKNN)
+res <- enn(circle_numeric, var = "class", all_k = TRUE)
 }
 \references{
 Wilson, D. L. (1972). Asymptotic properties of nearest neighbor

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -14,6 +14,7 @@ step_enn(
   neighbors = 3,
   distance = "euclidean",
   times = 1,
+  all_k = FALSE,
   skip = TRUE,
   seed = sample.int(10^5, 1),
   distance_with = recipes::all_predictors(),
@@ -55,6 +56,11 @@ applied. Defaults to \code{1} for a single pass. Values greater than \code{1} re
 the cleaning, stopping early once a pass removes no observations. Use
 \code{Inf} to repeat until convergence (Repeated Edited Nearest Neighbors).}
 
+\item{all_k}{A logical. When \code{TRUE}, ENN is applied with an increasing number
+of neighbors, from \code{1} up to \code{neighbors}, cleaning the data at each step
+(All k-Nearest Neighbors). Takes precedence over \code{times}. Defaults to
+\code{FALSE}.}
+
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some
 operations may not be able to be conducted on new data (e.g. processing the
@@ -93,6 +99,10 @@ Setting \code{times} greater than 1 applies ENN repeatedly, removing more noisy
 and borderline observations on each pass and stopping early once a pass
 removes nothing. This corresponds to Repeated Edited Nearest Neighbors
 (RENN).
+
+Setting \code{all_k = TRUE} applies ENN with increasing numbers of neighbors, from
+\code{1} up to \code{neighbors}, cleaning the data at each step. This corresponds to
+All k-Nearest Neighbors (AllKNN) and takes precedence over \code{times}.
 
 All variables selected by \code{distance_with} must be numeric with no missing
 data.

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -1,3 +1,35 @@
+# warns when both times and all_k are set
+
+    Code
+      tmp <- enn(circle_example[, c("x", "y", "class")], var = "class", times = 2,
+      all_k = TRUE)
+    Condition
+      Warning in `enn()`:
+      `times` is ignored when `all_k` is `TRUE`.
+
+---
+
+    Code
+      prep(step_enn(recipe(class ~ x + y, data = circle_example), class, times = 2,
+      all_k = TRUE))
+    Condition
+      Warning in `prep()`:
+      `times` is ignored when `all_k` is `TRUE`.
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:   1
+      predictor: 2
+      
+      -- Training information 
+      Training data contained 400 data points and no incomplete rows.
+      
+      -- Operations 
+      * ENN based on: class | Trained
+
 # errors when not enough observations for neighbors
 
     Code
@@ -92,6 +124,14 @@
       Error in `step_enn()`:
       Caused by error in `prep()`:
       ! `times` must be a whole number larger than or equal to 1, not the number -1.
+
+---
+
+    Code
+      step_enn(recipe(class ~ x + y, data = circle_example), class, all_k = 1)
+    Condition
+      Error in `step_enn()`:
+      ! `all_k` must be `TRUE` or `FALSE`, not the number 1.
 
 # bake method errors when needed non-standard role columns are missing
 

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -58,6 +58,48 @@ test_that("times converges before reaching the cap", {
   )
 })
 
+test_that("all_k applies ENN with increasing neighbors", {
+  set.seed(1)
+  n <- 200
+  noisy <- data.frame(
+    x = rnorm(n),
+    y = rnorm(n),
+    class = factor(sample(c("a", "b"), n, replace = TRUE))
+  )
+
+  n1 <- nrow(enn(noisy, var = "class", neighbors = 3, times = 1))
+  n_all <- nrow(enn(noisy, var = "class", neighbors = 3, all_k = TRUE))
+
+  expect_lt(n_all, n1)
+})
+
+test_that("all_k argument accepted by step_enn()", {
+  baked <- recipe(class ~ x + y, data = circle_example) |>
+    step_enn(class, all_k = TRUE) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_all_true(
+    as.vector(table(baked$class) <= table(circle_example$class))
+  )
+})
+
+test_that("warns when both times and all_k are set", {
+  expect_snapshot(
+    tmp <- enn(
+      circle_example[, c("x", "y", "class")],
+      var = "class",
+      times = 2,
+      all_k = TRUE
+    )
+  )
+  expect_snapshot(
+    recipe(class ~ x + y, data = circle_example) |>
+      step_enn(class, times = 2, all_k = TRUE) |>
+      prep()
+  )
+})
+
 test_that("errors when not enough observations for neighbors", {
   small <- circle_example[1:3, c("x", "y", "class")]
 
@@ -312,6 +354,11 @@ test_that("bad args", {
     recipe(class ~ x + y, data = circle_example) |>
       step_enn(class, times = -1) |>
       prep()
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ x + y, data = circle_example) |>
+      step_enn(class, all_k = 1)
   )
 })
 


### PR DESCRIPTION
Adds an `all_k` argument to `enn()` and `step_enn()` implementing All k-Nearest Neighbors (AllKNN), which applies ENN with an increasing number of neighbors from 1 up to `neighbors`, cleaning the data at each step. This mirrors how Repeated Edited Nearest Neighbors was added via the `times` argument. When both are set, `all_k` takes precedence and a warning is emitted since `times` is ignored (#174).