### PR TITLE
doc: update smotenc and step_smotenc references to include Gower (1971) for distance metric

### DIFF
--- a/R/smotenc.R
+++ b/R/smotenc.R
@@ -62,6 +62,9 @@
 #'  W. P. (2002). Smote: Synthetic minority over-sampling technique.
 #'  Journal of Artificial Intelligence Research, 16:321-357.
 #'
+#'  Gower, J. C. (1971). A general coefficient of similarity and some of
+#'  its properties. Biometrics 27(4):857-871. (For the distance metric used)
+#'
 #' @seealso [smotenc()] for direct implementation
 #' @family Steps for over-sampling
 #'

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -22,6 +22,9 @@
 #'  W. P. (2002). Smote: Synthetic minority over-sampling technique.
 #'  Journal of Artificial Intelligence Research, 16:321-357.
 #'
+#'  Gower, J. C. (1971). A general coefficient of similarity and some of
+#'  its properties. Biometrics 27(4):857-871. (For the distance metric used)
+#'
 #' @seealso [step_smotenc()] for step function of this method
 #' @family Direct Implementations
 #'

--- a/man/smotenc.Rd
+++ b/man/smotenc.Rd
@@ -52,11 +52,11 @@ res <- smotenc(circle_numeric, var = "class", over_ratio = 0.8)
 }
 \references{
 Chawla, N. V., Bowyer, K. W., Hall, L. O., and Kegelmeyer,
-  W. P. (2002). Smote: Synthetic minority over-sampling technique.
-  Journal of Artificial Intelligence Research, 16:321-357.
+W. P. (2002). Smote: Synthetic minority over-sampling technique.
+Journal of Artificial Intelligence Research, 16:321-357.
 
 Gower, J. C. (1971). A general coefficient of similarity and some of
-  its properties. Biometrics 27(4):857-871. (For the distance metric used)
+its properties. Biometrics 27(4):857-871. (For the distance metric used)
 }
 \seealso{
 \code{\link[=step_smotenc]{step_smotenc()}} for step function of this method

--- a/man/smotenc.Rd
+++ b/man/smotenc.Rd
@@ -52,8 +52,11 @@ res <- smotenc(circle_numeric, var = "class", over_ratio = 0.8)
 }
 \references{
 Chawla, N. V., Bowyer, K. W., Hall, L. O., and Kegelmeyer,
-W. P. (2002). Smote: Synthetic minority over-sampling technique.
-Journal of Artificial Intelligence Research, 16:321-357.
+  W. P. (2002). Smote: Synthetic minority over-sampling technique.
+  Journal of Artificial Intelligence Research, 16:321-357.
+
+Gower, J. C. (1971). A general coefficient of similarity and some of
+  its properties. Biometrics 27(4):857-871. (For the distance metric used)
 }
 \seealso{
 \code{\link[=step_smotenc]{step_smotenc()}} for step function of this method

--- a/man/step_smotenc.Rd
+++ b/man/step_smotenc.Rd
@@ -159,11 +159,11 @@ orig |>
 }
 \references{
 Chawla, N. V., Bowyer, K. W., Hall, L. O., and Kegelmeyer,
-  W. P. (2002). Smote: Synthetic minority over-sampling technique.
-  Journal of Artificial Intelligence Research, 16:321-357.
+W. P. (2002). Smote: Synthetic minority over-sampling technique.
+Journal of Artificial Intelligence Research, 16:321-357.
 
 Gower, J. C. (1971). A general coefficient of similarity and some of
-  its properties. Biometrics 27(4):857-871. (For the distance metric used)
+its properties. Biometrics 27(4):857-871. (For the distance metric used)
 }
 \seealso{
 \code{\link[=smotenc]{smotenc()}} for direct implementation

--- a/man/step_smotenc.Rd
+++ b/man/step_smotenc.Rd
@@ -159,8 +159,11 @@ orig |>
 }
 \references{
 Chawla, N. V., Bowyer, K. W., Hall, L. O., and Kegelmeyer,
-W. P. (2002). Smote: Synthetic minority over-sampling technique.
-Journal of Artificial Intelligence Research, 16:321-357.
+  W. P. (2002). Smote: Synthetic minority over-sampling technique.
+  Journal of Artificial Intelligence Research, 16:321-357.
+
+Gower, J. C. (1971). A general coefficient of similarity and some of
+  its properties. Biometrics 27(4):857-871. (For the distance metric used)
 }
 \seealso{
 \code{\link[=smotenc]{smotenc()}} for direct implementation


### PR DESCRIPTION
# doc: update smotenc and step_smotenc references to include Gower (1971) for distance metric

## Summary

This PR fixes the documentation for the `smotenc()` function to correctly cite the source of the distance metric it uses. The function's documentation previously only cited Chawla et al. (2002) for SMOTE, but the implementation actually uses Gower's distance to handle mixed data types. This update adds the appropriate citation for Gower (1971) and notes that it's used for the distance metric.

The `step_smotenc()` documentation is also updated for consistency, adding the same Gower citation since it also uses Gower's distance.

Fixes #266

## Changes

- Updated `smotenc()` function documentation in R/smotenc_impl.R to include Gower (1971) citation
- Updated `step_smotenc()` function documentation in R/smotenc.R to include Gower (1971) citation for consistency  
- Regenerated man/smotenc.Rd reference manual to reflect updated citations
- Regenerated man/step_smotenc.Rd reference manual to reflect updated citations

## Testing

The changes are documentation-only, so no functional testing was required. The documentation updates were verified by:
1. Checking that the .Rd files correctly reflect the added citations
2. Ensuring the citations follow the same format as existing references in the documentation
3. Verifying that both smotenc() and step_smotenc() documentation now consistently reference the Gower distance metric used in the implementation

---
### AI disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
