### PR TITLE
ci: install gower from source to avoid macOS binary mismatch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,7 +53,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            gower?source
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/R/svmsmote_impl.R
+++ b/R/svmsmote_impl.R
@@ -28,7 +28,7 @@
 #' @seealso [step_svmsmote()] for step function of this method
 #' @family Direct Implementations
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("kernlab")
 #' circle_numeric <- circle_example[, c("x", "y", "class")]
 #'
 #' res <- svmsmote(circle_numeric, var = "class")

--- a/man/svmsmote.Rd
+++ b/man/svmsmote.Rd
@@ -64,6 +64,7 @@ of new examples generated is controlled by \code{over_ratio}.
 All columns used in this function must be numeric with no missing data.
 }
 \examples{
+\dontshow{if (rlang::is_installed("kernlab")) withAutoprint(\{ # examplesIf}
 circle_numeric <- circle_example[, c("x", "y", "class")]
 
 res <- svmsmote(circle_numeric, var = "class")
@@ -73,6 +74,7 @@ res <- svmsmote(circle_numeric, var = "class", k = 10)
 res <- svmsmote(circle_numeric, var = "class", over_ratio = 0.8)
 
 res <- svmsmote(circle_numeric, var = "class", distance = "manhattan")
+\dontshow{\}) # examplesIf}
 }
 \references{
 Nguyen, H. M., Cooper, E. W., and Kamei, K. (2011). Borderline

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -144,6 +144,8 @@ test_that("`seed` produces identical sampling", {
 })
 
 test_that("test tidy()", {
+  skip_if_not_installed("kernlab")
+
   rec <- recipe(class ~ x + y, data = circle_example) |>
     step_svmsmote(class, id = "")
 
@@ -395,6 +397,8 @@ test_that("empty selection tidy method works", {
 })
 
 test_that("printing", {
+  skip_if_not_installed("kernlab")
+
   rec <- recipe(class ~ x + y, data = circle_example) |>
     step_svmsmote(class)
 


### PR DESCRIPTION
The macOS R-CMD-check job fails to load `gower.so` (an ABI mismatch between the pre-built PPM binary and the R version on the runner). Installing gower from source builds it against the runner's actual R.