### PR TITLE
Skip unused outcome factor levels in downsampling steps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # themis (development version)
 
+* `step_downsample()`, `step_nearmiss()`, and `step_instance_hardness()` no longer delete all rows when the outcome has an unused factor level. Zero-count levels are now dropped with a warning before sampling targets are computed (#238).
+
 * `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) was added. It cleans the data using the Edited Nearest Neighbors rule, removing observations whose class differs from the majority of their nearest neighbors (#115).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # themis (development version)
 
-* `step_downsample()`, `step_nearmiss()`, and `step_instance_hardness()` no longer delete all rows when the outcome has an unused factor level. Zero-count levels are now dropped with a warning before sampling targets are computed (#238).
+* All sampling steps now handle an unused (zero-count) factor level in the outcome gracefully, dropping it with a warning before computing sampling targets instead of deleting all rows or erroring (#238).
 
 * `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
 

--- a/R/adasyn.R
+++ b/R/adasyn.R
@@ -192,6 +192,7 @@ prep.step_adasyn <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   recipes::check_name(
     tibble(x = logical(0)),

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -58,10 +58,11 @@ adasyn_impl <- function(
   distance = "euclidean",
   call = caller_env()
 ) {
-  majority_count <- max(table(df[[var]]))
+  counts <- table(drop_unused_levels(df[[var]]))
+  majority_count <- max(counts)
   ratio_target <- majority_count * over_ratio
-  which_upsample <- which(table(df[[var]]) < ratio_target)
-  samples_needed <- ratio_target - table(df[[var]])[which_upsample]
+  which_upsample <- which(counts < ratio_target)
+  samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)
   out_dfs <- list()
 

--- a/R/bsmote.R
+++ b/R/bsmote.R
@@ -210,6 +210,7 @@ prep.step_bsmote <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   recipes::check_name(
     tibble(x = logical(0)),

--- a/R/bsmote_impl.R
+++ b/R/bsmote_impl.R
@@ -74,10 +74,11 @@ bsmote_impl <- function(
   distance = "euclidean",
   call = caller_env()
 ) {
-  majority_count <- max(table(df[[var]]))
+  counts <- table(drop_unused_levels(df[[var]]))
+  majority_count <- max(counts)
   ratio_target <- majority_count * over_ratio
-  which_upsample <- which(table(df[[var]]) < ratio_target)
-  samples_needed <- ratio_target - table(df[[var]])[which_upsample]
+  which_upsample <- which(counts < ratio_target)
+  samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)
   out_dfs <- list()
   data_mat <- as.matrix(df[names(df) != var])

--- a/R/cnn.R
+++ b/R/cnn.R
@@ -168,6 +168,7 @@ prep.step_cnn <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -203,11 +203,15 @@ prep.step_downsample <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   if (length(col_name) == 0) {
     minority <- 1
   } else {
-    obs_freq <- weighted_table(training[[col_name]], as.integer(wts))
+    obs_freq <- weighted_table(
+      droplevels(training[[col_name]]),
+      as.integer(wts)
+    )
     minority <- min(obs_freq)
   }
 

--- a/R/enn.R
+++ b/R/enn.R
@@ -205,6 +205,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/instance_hardness.R
+++ b/R/instance_hardness.R
@@ -195,6 +195,7 @@ prep.step_instance_hardness <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/misc.R
+++ b/R/misc.R
@@ -16,7 +16,10 @@ check_na <- function(data, step, call = caller_env()) {
 }
 
 check_2_levels_only <- function(data, col_name, call = caller_env()) {
-  if (length(col_name) == 1 && length(levels(data[[col_name]])) != 2) {
+  if (
+    length(col_name) == 1 &&
+      length(levels(drop_unused_levels(data[[col_name]]))) != 2
+  ) {
     cli::cli_abort(
       "The {.code {col_name}} must only have 2 levels.",
       call = call
@@ -70,6 +73,10 @@ check_column_factor <- function(data, column, call = caller_env()) {
   if (length(column) == 1 && !is.factor(data[[column]])) {
     cli::cli_abort("{.code {column}} should be a factor variable.", call = call)
   }
+}
+
+drop_unused_levels <- function(x) {
+  if (is.factor(x)) droplevels(x) else x
 }
 
 warn_unused_levels <- function(data, column, call = caller_env()) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -72,6 +72,29 @@ check_column_factor <- function(data, column, call = caller_env()) {
   }
 }
 
+warn_unused_levels <- function(data, column, call = caller_env()) {
+  if (length(column) != 1) {
+    return(invisible())
+  }
+
+  counts <- table(data[[column]])
+  empty <- names(counts)[counts == 0]
+
+  if (length(empty) > 0) {
+    cli::cli_warn(
+      c(
+        "{cli::qty(empty)} Unused factor level{?s} {.val {empty}} in \\
+         {.var {column}} {cli::qty(empty)}{?was/were} dropped.",
+        i = "{cli::qty(empty)} Level{?s} with zero observations {?is/are} \\
+             skipped when computing sampling targets."
+      ),
+      call = call
+    )
+  }
+
+  invisible()
+}
+
 check_column_numeric <- function(data, column, call = caller_env()) {
   if (length(column) == 1 && !is.numeric(data[[column]])) {
     cli::cli_abort(

--- a/R/ncl.R
+++ b/R/ncl.R
@@ -196,6 +196,7 @@ prep.step_ncl <- function(
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/nearmiss.R
+++ b/R/nearmiss.R
@@ -200,6 +200,7 @@ prep.step_nearmiss <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/nearmiss_impl.R
+++ b/R/nearmiss_impl.R
@@ -101,7 +101,7 @@ nearmiss_impl <- function(
 }
 
 downsample_count <- function(data, var, ratio) {
-  counts <- table(droplevels(data[[var]]))
+  counts <- table(drop_unused_levels(data[[var]]))
   min_count <- min(counts)
   ratio_target <- min_count * ratio
   which_class <- which(counts > ratio_target)

--- a/R/nearmiss_impl.R
+++ b/R/nearmiss_impl.R
@@ -101,10 +101,11 @@ nearmiss_impl <- function(
 }
 
 downsample_count <- function(data, var, ratio) {
-  min_count <- min(table(data[[var]]))
+  counts <- table(droplevels(data[[var]]))
+  min_count <- min(counts)
   ratio_target <- min_count * ratio
-  which_class <- which(table(data[[var]]) > ratio_target)
-  table(data[[var]])[which_class] - ratio_target
+  which_class <- which(counts > ratio_target)
+  counts[which_class] - ratio_target
 }
 
 subset_to_matrix <- function(data, var, class, equal = TRUE) {

--- a/R/oss.R
+++ b/R/oss.R
@@ -169,6 +169,7 @@ prep.step_oss <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/rose.R
+++ b/R/rose.R
@@ -201,6 +201,7 @@ prep.step_rose <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
   check_2_levels_only(training, col_name)
 
   recipes::check_name(
@@ -370,8 +371,9 @@ rose <- function(
   check_number_decimal(majority_smoothness, min = 0)
   check_2_levels_only(df, var)
 
-  majority_size <- max(table(df[[var]])) * 2
   original_levels <- levels(df[[var]])
+  df[[var]] <- drop_unused_levels(df[[var]])
+  majority_size <- max(table(df[[var]])) * 2
   synthetic_data <- ROSE(
     string2formula(var),
     df,

--- a/R/smote.R
+++ b/R/smote.R
@@ -197,6 +197,7 @@ prep.step_smote <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   recipes::check_name(
     tibble(x = logical(0)),

--- a/R/smote_impl.R
+++ b/R/smote_impl.R
@@ -59,10 +59,11 @@ smote_impl <- function(
   call = caller_env()
 ) {
   data <- split(df, df[[var]])
-  majority_count <- max(table(df[[var]]))
+  counts <- table(drop_unused_levels(df[[var]]))
+  majority_count <- max(counts)
   ratio_target <- majority_count * over_ratio
-  which_upsample <- which(table(df[[var]]) < ratio_target)
-  samples_needed <- ratio_target - table(df[[var]])[which_upsample]
+  which_upsample <- which(counts < ratio_target)
+  samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)
 
   out_dfs <- list()

--- a/R/smoten.R
+++ b/R/smoten.R
@@ -161,6 +161,7 @@ prep.step_smoten <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   predictors <- setdiff(recipes::recipes_names_predictors(info), col_name)
   check_na(select(training, all_of(c(col_name, predictors))))

--- a/R/smoten_impl.R
+++ b/R/smoten_impl.R
@@ -59,13 +59,14 @@ smoten_impl <- function(df, var, k, over_ratio, call = caller_env()) {
   # split data into list names by classes
   data <- split(df, df[[var]])
   # Number of majority instances
-  majority_count <- max(table(df[[var]]))
+  counts <- table(drop_unused_levels(df[[var]]))
+  majority_count <- max(counts)
   # How many minority samples do we want in total?
   ratio_target <- majority_count * over_ratio
   # Which classes need upsampling
-  which_upsample <- which(table(df[[var]]) < ratio_target)
+  which_upsample <- which(counts < ratio_target)
   # For each minority class, determine how many more samples are needed
-  samples_needed <- ratio_target - table(df[[var]])[which_upsample]
+  samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)
 
   out_dfs <- list()

--- a/R/smotenc.R
+++ b/R/smotenc.R
@@ -174,6 +174,7 @@ prep.step_smotenc <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   recipes::check_name(
     tibble(x = logical(0)),

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -53,14 +53,15 @@ smotenc_impl <- function(df, var, k, over_ratio, call = caller_env()) {
   # split data into list names by classes
   data <- split(df, df[[var]])
   # Number of majority instances
-  majority_count <- max(table(df[[var]]))
+  counts <- table(drop_unused_levels(df[[var]]))
+  majority_count <- max(counts)
   # How many minority samples do we want in total?
   ratio_target <- majority_count * over_ratio
   # How many classes do we need to upsample (account for 2+ classes!)
   # Get the indices of those classes
-  which_upsample <- which(table(df[[var]]) < ratio_target)
+  which_upsample <- which(counts < ratio_target)
   # For each minorty class, determine how many more samples are needed
-  samples_needed <- ratio_target - table(df[[var]])[which_upsample]
+  samples_needed <- ratio_target - counts[which_upsample]
   # Just saving the names of those classes
   min_names <- names(samples_needed)
 

--- a/R/svmsmote.R
+++ b/R/svmsmote.R
@@ -188,6 +188,7 @@ prep.step_svmsmote <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   recipes::check_name(
     tibble(x = logical(0)),

--- a/R/svmsmote_impl.R
+++ b/R/svmsmote_impl.R
@@ -66,10 +66,11 @@ svmsmote_impl <- function(
   m <- 2 * k
   out_step <- 0.5
 
-  majority_count <- max(table(df[[var]]))
+  counts <- table(drop_unused_levels(df[[var]]))
+  majority_count <- max(counts)
   ratio_target <- majority_count * over_ratio
-  which_upsample <- which(table(df[[var]]) < ratio_target)
-  samples_needed <- ratio_target - table(df[[var]])[which_upsample]
+  which_upsample <- which(counts < ratio_target)
+  samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)
   out_dfs <- list()
 

--- a/R/tomek.R
+++ b/R/tomek.R
@@ -167,6 +167,7 @@ prep.step_tomek <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   distance_cols <- recipes_argument_select(
     x$distance_with,

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -209,6 +209,7 @@ prep.step_upsample <- function(x, training, info = NULL, ...) {
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
+  warn_unused_levels(training, col_name)
 
   if (length(col_name) == 0) {
     majority <- 0

--- a/tests/testthat/_snaps/adasyn.md
+++ b/tests/testthat/_snaps/adasyn.md
@@ -109,6 +109,16 @@
       Error in `step_adasyn()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_adasyn(recipe(class ~ x + y, data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/bsmote.md
+++ b/tests/testthat/_snaps/bsmote.md
@@ -118,6 +118,16 @@
       Error in `step_bsmote()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_bsmote(recipe(class ~ x + y, data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/cnn.md
+++ b/tests/testthat/_snaps/cnn.md
@@ -63,6 +63,16 @@
       Error in `step_cnn()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_cnn(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/downsample.md
+++ b/tests/testthat/_snaps/downsample.md
@@ -80,6 +80,16 @@
       Error in `step_downsample()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_downsample(recipe(class ~ ., data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -133,6 +133,16 @@
       Error in `step_enn()`:
       ! `all_k` must be `TRUE` or `FALSE`, not the number 1.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_enn(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/instance_hardness.md
+++ b/tests/testthat/_snaps/instance_hardness.md
@@ -92,6 +92,16 @@
       Error in `step_instance_hardness()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_instance_hardness(recipe(class ~ x + y, data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/ncl.md
+++ b/tests/testthat/_snaps/ncl.md
@@ -94,6 +94,16 @@
       Caused by error in `prep()`:
       ! `threshold_clean` must be a number larger than or equal to 0, not the number -1.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_ncl(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/nearmiss.md
+++ b/tests/testthat/_snaps/nearmiss.md
@@ -91,6 +91,16 @@
       Error in `step_nearmiss()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_nearmiss(recipe(class ~ x + y, data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/oss.md
+++ b/tests/testthat/_snaps/oss.md
@@ -63,6 +63,16 @@
       Error in `step_oss()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_oss(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/rose.md
+++ b/tests/testthat/_snaps/rose.md
@@ -168,6 +168,16 @@
       Error in `rose()`:
       ! The `class` must only have 2 levels.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_rose(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/smote.md
+++ b/tests/testthat/_snaps/smote.md
@@ -109,6 +109,16 @@
       Error in `step_smote()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_smote(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/smoten.md
+++ b/tests/testthat/_snaps/smoten.md
@@ -61,6 +61,16 @@
       Error in `step_smoten()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_smoten(recipe(class ~ x + y, data = cat_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/smotenc.md
+++ b/tests/testthat/_snaps/smotenc.md
@@ -90,6 +90,16 @@
       Error in `step_smotenc()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_smotenc(recipe(class ~ x + y, data = df), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/svmsmote.md
+++ b/tests/testthat/_snaps/svmsmote.md
@@ -109,6 +109,16 @@
       Error in `step_svmsmote()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_svmsmote(recipe(class ~ x + y, data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/tomek.md
+++ b/tests/testthat/_snaps/tomek.md
@@ -63,6 +63,16 @@
       Error in `step_tomek()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_tomek(recipe(class ~ x + y, data = circle_example), class)),
+      new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/_snaps/upsample.md
+++ b/tests/testthat/_snaps/upsample.md
@@ -109,6 +109,16 @@
       Error in `step_upsample()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# unused outcome levels are skipped with a warning (#238)
+
+    Code
+      res <- bake(prep(step_upsample(recipe(class ~ x + y, data = circle_example),
+      class)), new_data = NULL)
+    Condition
+      Warning in `prep()`:
+      Unused factor level "unused" in `class` was dropped.
+      i  Level with zero observations is skipped when computing sampling targets.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -374,6 +374,22 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_adasyn(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -490,6 +490,22 @@ test_that("bsmote() passes all_neighbors to bsmote_impl()", {
   expect_false(identical(res_false, res_true))
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_bsmote(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-cnn.R
+++ b/tests/testthat/test-cnn.R
@@ -262,6 +262,22 @@ test_that("bad args", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_cnn(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -288,6 +288,23 @@ test_that("NA values in outcome are handled", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example <- circle_example[, c("x", "y", "class")]
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ ., data = circle_example) |>
+      step_downsample(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -362,6 +362,22 @@ test_that("bad args", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_enn(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-instance_hardness.R
+++ b/tests/testthat/test-instance_hardness.R
@@ -320,6 +320,22 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_instance_hardness(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-ncl.R
+++ b/tests/testthat/test-ncl.R
@@ -315,6 +315,22 @@ test_that("bad args", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_ncl(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -336,6 +336,22 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_nearmiss(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-oss.R
+++ b/tests/testthat/test-oss.R
@@ -274,6 +274,22 @@ test_that("bad args", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_oss(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -381,6 +381,22 @@ test_that("rose() errors on more than 2 class levels", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_rose(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -370,6 +370,22 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_smote(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smoten.R
+++ b/tests/testthat/test-smoten.R
@@ -265,6 +265,22 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  cat_example$class <- factor(
+    cat_example$class,
+    levels = c(levels(cat_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = cat_example) |>
+      step_smoten(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -354,6 +354,27 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  set.seed(1)
+  df <- data.frame(
+    x = factor(sample(letters[1:3], 200, replace = TRUE)),
+    y = rnorm(200),
+    class = factor(
+      sample(c("a", "b"), 200, replace = TRUE, prob = c(0.8, 0.2)),
+      levels = c("a", "b", "unused")
+    )
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = df) |>
+      step_smotenc(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -341,6 +341,24 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
   expect_identical(nrow(params), 2L)
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  skip_if_not_installed("kernlab")
+
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_svmsmote(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-tomek.R
+++ b/tests/testthat/test-tomek.R
@@ -237,6 +237,22 @@ test_that("bad args", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_tomek(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -320,6 +320,22 @@ test_that("NA values in outcome are handled", {
   )
 })
 
+test_that("unused outcome levels are skipped with a warning (#238)", {
+  circle_example$class <- factor(
+    circle_example$class,
+    levels = c(levels(circle_example$class), "unused")
+  )
+
+  expect_snapshot(
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_upsample(class) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+
+  expect_gt(nrow(res), 0)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
When the outcome factor had an unused (zero-count) level, `min(table(outcome))` returned zero, so `step_downsample()`, `step_nearmiss()`, and `step_instance_hardness()` silently sampled every class to zero rows, and the oversampling steps (`step_smote()`, `step_bsmote()`, `step_svmsmote()`, `step_smoten()`, `step_smotenc()`, `step_adasyn()`) errored trying to synthesize for an empty class. `step_rose()` rejected the empty level as a disallowed third level. Unused levels are common after filtering, so this bit users with no indication of why their data vanished. Fixes #238.

Every sampling step now drops zero-count outcome levels before computing targets and emits a warning at `prep()`. Each step has a test covering the unused-level case.