### PR TITLE
Fix nearmiss keeping the wrong rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * `step_ncl()` (and its direct-implementation counterpart `ncl()`) was added. It cleans the data using the Neighborhood Cleaning Rule, removing majority class observations that are noisy or that pollute the neighborhood of minority class observations (#116).
 
+* `step_nearmiss()` (and its direct-implementation counterpart `nearmiss()`) now keeps the majority observations that are genuinely closest to the minority class, rather than selecting rows by their position in the data (#236).
+
 * `step_oss()` (and its direct-implementation counterpart `oss()`) was added. It under-samples the majority classes using One-Sided Selection, combining Condensed Nearest Neighbors to reduce redundant majority class observations with Tomek's links to remove majority class observations on the decision boundary (#114).
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) was added. It over-samples rare regions of a numeric outcome for imbalanced regression using a combination of SMOTE-style interpolation and Gaussian noise, while under-sampling common regions (#49).

--- a/R/nearmiss_impl.R
+++ b/R/nearmiss_impl.R
@@ -87,7 +87,8 @@ nearmiss_impl <- function(
 
     dists <- nn_dists_cross(class, not_class, k, distance)
 
-    selected_ind <- order(rowMeans(dists)) <= (nrow(class) - classes[i])
+    selected_ind <- rank(rowMeans(dists), ties.method = "first") <=
+      (nrow(class) - classes[i])
     deleted_rows <- c(
       deleted_rows,
       which(df[[var]] %in% names(classes)[i])[!selected_ind]

--- a/tests/testthat/test-nearmiss_impl.R
+++ b/tests/testthat/test-nearmiss_impl.R
@@ -60,6 +60,18 @@ test_that("nearmiss with k=2 uses mean distance to keep closest majority points"
   expect_equal(sort(result$x[result$class == "maj"]), c(4, 9, 20))
 })
 
+test_that("nearmiss keeps the closest rows regardless of row order (#236)", {
+  df <- data.frame(
+    x = c(0, -100, 10, 1, 11, 2, 3),
+    y = rep(0, 7),
+    class = factor(c("min", "min", "maj", "maj", "maj", "maj", "maj"))
+  )
+  result <- nearmiss(df, var = "class", k = 1, under_ratio = 1)
+  # Nearest minority point is x=0, so distance is |x|. under_ratio=1 keeps the
+  # 2 closest majority points {1, 2}, not the positionally-selected rows.
+  expect_equal(sort(result$x[result$class == "maj"]), c(1, 2))
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
`nearmiss()` selected which majority observations to keep with `order(rowMeans(dists)) <= n`, but `order()` returns a permutation, not ranks, so the comparison kept observations by their position in the data rather than by their distance to the minority class. The count kept was correct but the rows were wrong. Switching to `rank(..., ties.method = "first")` keeps the genuinely closest observations, matching the sibling `instance_hardness_impl.R`.

Fixes #236.