### PR TITLE
Use correct Cholesky factor for mahalanobis whitening

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -203,7 +203,7 @@ nn_indices <- function(data, k, distance) {
       )
     }
     S <- stats::cov(data)
-    data_w <- data %*% solve(t(chol(S)))
+    data_w <- data %*% solve(chol(S))
     return(RANN::nn2(data_w, k = k + 1, searchtype = "priority")$nn.idx)
   }
   dist_method <- switch(
@@ -237,7 +237,7 @@ nn_dists_cross <- function(query, reference, k, distance) {
       )
     }
     S <- stats::cov(reference)
-    L_inv <- solve(t(chol(S)))
+    L_inv <- solve(chol(S))
     reference_w <- reference %*% L_inv
     query_w <- query %*% L_inv
     return(RANN::nn2(reference_w, query_w, k = k)$nn.dists)
@@ -276,7 +276,7 @@ nn_indices_cross <- function(query, reference, k, distance) {
       )
     }
     S <- stats::cov(reference)
-    L_inv <- solve(t(chol(S)))
+    L_inv <- solve(chol(S))
     reference_w <- reference %*% L_inv
     query_w <- query %*% L_inv
     return(RANN::nn2(reference_w, query_w, k = k)$nn.idx)

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -217,7 +217,7 @@ smogn_distmat <- function(data, distance) {
   }
   if (distance == "mahalanobis") {
     S <- stats::cov(data)
-    data <- data %*% solve(t(chol(S)))
+    data <- data %*% solve(chol(S))
     return(as.matrix(stats::dist(data)))
   }
   method <- switch(

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -43,3 +43,18 @@ test_that("nn_indices() uses the correct distance metric", {
   expect_equal(nn1(nn_indices(data_mahal, 1, "euclidean"), 1), 2L)
   expect_equal(nn1(nn_indices(data_mahal, 1, "mahalanobis"), 1), 3L)
 })
+
+test_that("mahalanobis whitening reproduces stats::mahalanobis distances (#237)", {
+  set.seed(1)
+  n <- 200
+  x1 <- rnorm(n)
+  data <- cbind(x1, 2 * x1 + rnorm(n, sd = 0.3), rnorm(n), x1 - rnorm(n))
+  S <- stats::cov(data)
+
+  whitened <- data %*% solve(chol(S))
+  center <- whitened[1, ]
+  themis_d2 <- rowSums(sweep(whitened, 2, center)^2)
+  true_d2 <- stats::mahalanobis(data, data[1, ], S)
+
+  expect_equal(themis_d2, unname(true_d2))
+})


### PR DESCRIPTION
`distance = "mahalanobis"` whitened the data with `solve(t(chol(S)))`, which produces `(RRᵀ)⁻¹` rather than the inverse covariance, so the resulting distances and nearest-neighbor sets were wrong on correlated data. Switching to `solve(chol(S))` makes the whitened Euclidean distances match true Mahalanobis distances. Fixes #237.