### PR TITLE
Return a factor outcome for a character var in SMOTE-family samplers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 
 * All `step_*()` functions now correctly handle 0 and 1 row inputs in `bake()` (#160).
 
+* `adasyn()`, `bsmote()`, `smote()`, `smoten()`, `smotenc()`, and `svmsmote()` now return a proper factor outcome when called with a character `var`, instead of an all-`NA`, zero-level factor (#261).
+
 * `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()` now correctly attribute errors from non-numeric columns to the user-facing function (#181).
 
 * `smotenc()` now only suppresses the specific benign warning from `gower::gower_topn()` about variables with zero range, rather than all warnings (#182).

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -58,6 +58,7 @@ adasyn_impl <- function(
   distance = "euclidean",
   call = caller_env()
 ) {
+  df[[var]] <- as.factor(df[[var]])
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
   ratio_target <- majority_count * over_ratio

--- a/R/bsmote_impl.R
+++ b/R/bsmote_impl.R
@@ -74,6 +74,7 @@ bsmote_impl <- function(
   distance = "euclidean",
   call = caller_env()
 ) {
+  df[[var]] <- as.factor(df[[var]])
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
   ratio_target <- majority_count * over_ratio

--- a/R/smote_impl.R
+++ b/R/smote_impl.R
@@ -58,6 +58,7 @@ smote_impl <- function(
   distance = "euclidean",
   call = caller_env()
 ) {
+  df[[var]] <- as.factor(df[[var]])
   data <- split(df, df[[var]])
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)

--- a/R/smoten_impl.R
+++ b/R/smoten_impl.R
@@ -52,6 +52,7 @@ smoten <- function(df, var, k = 5, over_ratio = 1) {
 
 # Splits data and appends new minority instances
 smoten_impl <- function(df, var, k, over_ratio, call = caller_env()) {
+  df[[var]] <- as.factor(df[[var]])
   predictors <- setdiff(names(df), var)
   # per-feature Value Difference Metric between category levels
   deltas <- vdm_deltas(df, var, predictors)

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -50,6 +50,7 @@ smotenc <- function(df, var, k = 5, over_ratio = 1) {
 
 # Splits data and appends new minority instances
 smotenc_impl <- function(df, var, k, over_ratio, call = caller_env()) {
+  df[[var]] <- as.factor(df[[var]])
   # split data into list names by classes
   data <- split(df, df[[var]])
   # Number of majority instances

--- a/R/svmsmote_impl.R
+++ b/R/svmsmote_impl.R
@@ -61,6 +61,7 @@ svmsmote_impl <- function(
   distance = "euclidean",
   call = caller_env()
 ) {
+  df[[var]] <- as.factor(df[[var]])
   # `m` neighbors are used to classify support vectors as noise, danger, or
   # safety; `out_step` controls how far extrapolated examples are placed.
   m <- 2 * k

--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -390,6 +390,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("adasyn() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- adasyn(df, "class")
+
+  expect_s3_class(res$class, "factor")
+  expect_identical(levels(res$class), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -506,6 +506,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("bsmote() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- bsmote(df, "class")
+
+  expect_s3_class(res$class, "factor")
+  expect_identical(levels(res$class), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-cnn.R
+++ b/tests/testthat/test-cnn.R
@@ -278,6 +278,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("cnn() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- cnn(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -378,6 +378,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("enn() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- enn(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-instance_hardness.R
+++ b/tests/testthat/test-instance_hardness.R
@@ -336,6 +336,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("instance_hardness() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- instance_hardness(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-ncl.R
+++ b/tests/testthat/test-ncl.R
@@ -331,6 +331,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("ncl() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- ncl(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -352,6 +352,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("nearmiss() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- nearmiss(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-oss.R
+++ b/tests/testthat/test-oss.R
@@ -290,6 +290,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("oss() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- oss(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -386,6 +386,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("smote() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- smote(df, "class")
+
+  expect_s3_class(res$class, "factor")
+  expect_identical(levels(res$class), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smoten.R
+++ b/tests/testthat/test-smoten.R
@@ -281,6 +281,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("smoten() works with a character `var` (#261)", {
+  df <- cat_example
+  df$class <- as.character(df$class)
+
+  res <- smoten(df, "class")
+
+  expect_s3_class(res$class, "factor")
+  expect_identical(sort(levels(res$class)), c("common", "rare"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -375,6 +375,20 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("smotenc() works with a character `var` (#261)", {
+  df <- data.frame(
+    x = rnorm(60),
+    y = factor(sample(letters[1:3], 60, replace = TRUE)),
+    class = c(rep("min", 20), rep("maj", 40))
+  )
+
+  res <- smotenc(df, "class")
+
+  expect_s3_class(res$class, "factor")
+  expect_identical(sort(levels(res$class)), c("maj", "min"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -359,6 +359,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("svmsmote() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- svmsmote(df, "class")
+
+  expect_s3_class(res$class, "factor")
+  expect_identical(levels(res$class), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -360,6 +360,8 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
 })
 
 test_that("svmsmote() works with a character `var` (#261)", {
+  skip_if_not_installed("kernlab")
+
   df <- circle_example[c("x", "y", "class")]
   df$class <- as.character(df$class)
 

--- a/tests/testthat/test-tomek.R
+++ b/tests/testthat/test-tomek.R
@@ -253,6 +253,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("tomek() works with a character `var` (#261)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$class <- as.character(df$class)
+
+  res <- tomek(df, "class")
+
+  expect_type(res$class, "character")
+  expect_identical(sort(unique(res$class)), c("Circle", "Rest"))
+  expect_identical(sum(is.na(res$class)), 0L)
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
The exported synthesis samplers (`smote()`, `bsmote()`, `adasyn()`, `svmsmote()`, `smotenc()`, `smoten()`) accept a character `var`, but rebuilt the outcome from `levels(df[[var]])`, which is `NULL` for a character column and silently produced an all-`NA`, zero-level factor. They now coerce the column to a factor up front and return a proper factor. Regression tests are also added for the down-sampling methods, which were unaffected (they subset rows rather than rebuild the outcome) but should stay that way.

Fixes #261.