### PR TITLE
Handle well-separated classes in ADASYN (#240)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * All sampling steps now handle an unused (zero-count) factor level in the outcome gracefully, dropping it with a warning before computing sampling targets instead of deleting all rows or erroring (#238).
 
+* `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) no longer errors with a cryptic message when a minority class is well separated from the majority classes; it now falls back to uniform sampling and checks the minority class size before sampling (#240).
+
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) now selects the correct "danger" observations on the class border. The danger criterion had inverted the roles of minority and majority neighbors, causing it to oversample safe interior points instead of borderline ones (#235).
 
 * `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -73,18 +73,6 @@ adasyn_impl <- function(
   for (i in seq_along(min_names)) {
     min_class_in <- df[[var]] != min_names[i]
 
-    r_value <- pmax(
-      0,
-      rowSums(matrix((min_class_in)[ids_full], ncol = ncol(ids_full))) - 1
-    )
-    r_value <- r_value[!min_class_in]
-    danger_ids <- sample(
-      seq_along(r_value),
-      samples_needed[i],
-      TRUE,
-      prob = r_value
-    )
-
     minority <- data_mat[!min_class_in, , drop = FALSE]
 
     if (nrow(minority) <= k) {
@@ -96,6 +84,23 @@ adasyn_impl <- function(
         call = call
       )
     }
+
+    r_value <- pmax(
+      0,
+      rowSums(matrix((min_class_in)[ids_full], ncol = ncol(ids_full))) - 1
+    )
+    r_value <- r_value[!min_class_in]
+    # When the minority class is well separated from the majority classes all
+    # weights are 0, which `sample()` cannot use. Fall back to uniform sampling.
+    if (all(r_value == 0)) {
+      r_value <- NULL
+    }
+    danger_ids <- sample(
+      seq_along(minority[, 1]),
+      samples_needed[i],
+      TRUE,
+      prob = r_value
+    )
 
     tmp_df <- as.data.frame(
       adasyn_sampler(

--- a/tests/testthat/test-adasyn.R
+++ b/tests/testthat/test-adasyn.R
@@ -401,6 +401,19 @@ test_that("adasyn() works with a character `var` (#261)", {
   expect_identical(sum(is.na(res$class)), 0L)
 })
 
+test_that("adasyn() works with well-separated classes (#240)", {
+  set.seed(1)
+  df <- data.frame(
+    x = c(rnorm(50, 0), rnorm(20, 100)),
+    y = c(rnorm(50, 0), rnorm(20, 100)),
+    class = factor(c(rep("a", 50), rep("b", 20)))
+  )
+
+  res <- adasyn(df, "class")
+
+  expect_identical(as.numeric(table(res$class)), c(50, 50))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
`adasyn()` called `sample(prob = r_value)` before checking that the minority class had enough observations, so a class well separated from the majority (where every ADASYN weight is 0) aborted with the cryptic `too few positive probabilities` error rather than a useful message. This moves the size guard ahead of the sampling and falls back to uniform sampling when all weights are 0, so separable classes oversample cleanly. Closes #240.