### PR TITLE
Drop off-by-one in ADASYN majority-neighbor count

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * All sampling steps now handle an unused (zero-count) factor level in the outcome gracefully, dropping it with a warning before computing sampling targets instead of deleting all rows or erroring (#238).
 
+* `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) now weights minority observations by their exact majority-neighbor count. An off-by-one subtraction previously undercounted majority neighbors, zeroing out the weight of border points with a single majority neighbor and biasing sampling away from the class boundary (#239).
+
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) no longer errors with a cryptic message when a minority class is well separated from the majority classes; it now falls back to uniform sampling and checks the minority class size before sampling (#240).
 
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) now selects the correct "danger" observations on the class border. The danger criterion had inverted the roles of minority and majority neighbors, causing it to oversample safe interior points instead of borderline ones (#235).

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -85,10 +85,7 @@ adasyn_impl <- function(
       )
     }
 
-    r_value <- pmax(
-      0,
-      rowSums(matrix((min_class_in)[ids_full], ncol = ncol(ids_full))) - 1
-    )
+    r_value <- rowSums(matrix((min_class_in)[ids_full], ncol = ncol(ids_full)))
     r_value <- r_value[!min_class_in]
     # When the minority class is well separated from the majority classes all
     # weights are 0, which `sample()` cannot use. Fall back to uniform sampling.

--- a/tests/testthat/test-adasyn_impl.R
+++ b/tests/testthat/test-adasyn_impl.R
@@ -83,6 +83,44 @@ test_that("adasyn generates synthetic points only near minority-majority boundar
   expect_equal(sum(synthetic$x <= 10), 0L)
 })
 
+test_that("adasyn weights border points with a single majority neighbor", {
+  # Border minority points near a majority point each have exactly one majority
+  # neighbor. The `- 1` off-by-one used to zero out their weight (#239), so
+  # synthetic points should be seeded from the border cluster, not the isolated
+  # minority cluster that has no majority neighbors.
+  df <- data.frame(
+    x = c(
+      10,
+      10.1,
+      10.2,
+      10.3,
+      10.4, # border minority cluster
+      200,
+      200.1,
+      200.2,
+      200.3, # isolated minority (no majority neighbors)
+      10.5, # majority next to the border cluster
+      100,
+      101,
+      102,
+      103,
+      104,
+      105,
+      106,
+      107,
+      108,
+      109,
+      110,
+      111 # far majority cluster
+    ),
+    class = factor(c(rep("min", 9), rep("maj", 13)))
+  )
+  set.seed(1)
+  result <- adasyn(df, var = "class", k = 3, over_ratio = 1)
+  synthetic <- tail(result, nrow(result) - nrow(df))
+  expect_equal(sum(synthetic$x > 30), 0L)
+})
+
 test_that("adasyn() interfaces correctly", {
   expect_no_error(adasyn(circle_example_num, var = "class"))
 


### PR DESCRIPTION
ADASYN weights minority observations by their number of majority-class neighbors, but the weight computation subtracted one from that count. Since the neighbor sum here already equals the majority-neighbor count (a minority row's self contributes 0, unlike in bsmote where it is counted), the subtraction zeroed out border points with a single majority neighbor and biased sampling away from the class boundary, the opposite of ADASYN's intent. This drops the `- 1` so the weights match He (2008). Fixes #239.