### PR TITLE
Add @source for circle_example and fix documented row count

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -3,11 +3,12 @@
 #' A random dataset with two classes one of which is inside a circle. Used for
 #' examples to show how the different methods handles borders.
 #'
-#' @format A data frame with 200 rows and 4 variables:
+#' @format A data frame with 400 rows and 4 variables:
 #' \describe{
 #'   \item{x}{Numeric.}
 #'   \item{y}{Numeric.}
 #'   \item{class}{Factor, values "Circle" and "Rest".}
 #'   \item{id}{character, ID variable.}
 #' }
+#' @source Synthetic data, simulated in \code{data-raw/circle_example.R}.
 "circle_example"

--- a/man/circle_example.Rd
+++ b/man/circle_example.Rd
@@ -5,13 +5,16 @@
 \alias{circle_example}
 \title{Synthetic Dataset With a Circle}
 \format{
-A data frame with 200 rows and 4 variables:
+A data frame with 400 rows and 4 variables:
 \describe{
 \item{x}{Numeric.}
 \item{y}{Numeric.}
 \item{class}{Factor, values "Circle" and "Rest".}
 \item{id}{character, ID variable.}
 }
+}
+\source{
+Synthetic data, simulated in \code{data-raw/circle_example.R}.
 }
 \usage{
 circle_example


### PR DESCRIPTION
Adds the one-line @source pointing at data-raw/circle_example.R and regenerates the Rd. While in there I noticed @format said 200 rows but the shipped data has 400 (data-raw draws runif(400)), so I corrected that too.

Fixes #268