### PR TITLE
Vote SMOTENC nominal features over the seed's k neighbors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 * `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
 
+* `step_smotenc()` (and its direct-implementation counterpart `smotenc()`) now sets each synthetic sample's nominal features to the majority vote across the seed's k nearest neighbors, matching the SMOTENC algorithm, rather than voting over the randomly chosen interpolation partners (#241).
+
 * `step_svmsmote()` (and its direct-implementation counterpart `svmsmote()`) was added. It over-samples the minority classes near the decision boundary by fitting a support vector machine and generating new examples around the minority class support vectors, interpolating in dense regions and extrapolating in sparse ones (#170).
 
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -169,12 +169,8 @@ smotenc_data <- function(
     ] +
       gap
 
-    # Replace categories with most frequent among nearest neighbors
-    cat_to_upgrade <- data_factors[
-      id_knn[sampleids[index_selection]],
-      ,
-      drop = FALSE
-    ]
+    # Replace categories with the most frequent among the seed's k neighbors
+    cat_to_upgrade <- data_factors[id_knn, , drop = FALSE]
 
     cat_modes <- apply(cat_to_upgrade, 2, Mode)
 

--- a/tests/testthat/test-smotenc_impl.R
+++ b/tests/testthat/test-smotenc_impl.R
@@ -13,6 +13,32 @@ test_that("smotenc assigns categorical column by majority vote of minority neigh
   expect_true(all(as.character(synthetic$cat) == "a"))
 })
 
+test_that("categorical vote uses all k neighbors, not the chosen partner", {
+  # Minority points sit close together; the many numeric columns dilute the
+  # categorical weight in the gower distance so the "b" point stays a genuine
+  # nearest neighbor. Every minority point's 3 nearest neighbors then hold a
+  # strict "a" majority, so the k-neighbor mode is always "a". Copying a single
+  # random partner's category would instead emit "b" whenever the "b" point is
+  # picked as an interpolation partner.
+  x1 <- c(0, 1, 2, 3, 4, 100 + seq_len(10))
+  df <- data.frame(
+    x1 = x1,
+    x2 = x1,
+    x3 = x1,
+    x4 = x1,
+    x5 = x1,
+    x6 = x1,
+    x7 = x1,
+    x8 = x1,
+    cat = factor(c("a", "a", "b", "a", "a", rep("x", 10))),
+    class = factor(c(rep("min", 5), rep("maj", 10)))
+  )
+  set.seed(1)
+  result <- smotenc(df, var = "class", k = 3, over_ratio = 1)
+  synthetic <- tail(result, nrow(result) - nrow(df))
+  expect_all_equal(as.character(synthetic$cat), "a")
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
SMOTENC set each synthetic sample's nominal features from the randomly chosen interpolation partners rather than from a majority vote across the seed's k nearest neighbors. This diverges from the SMOTENC algorithm (Chawla 2002) and from the correct `smoten_impl()` implementation, and degenerates to copying a single random neighbor's category when a seed produces one sample. This now votes over the seed's k neighbors, matching `smoten_impl()`. Fixes #241.