### PR TITLE
Seed borderline-SMOTE2 only from minority danger points (#242)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) now selects the correct "danger" observations on the class border. The danger criterion had inverted the roles of minority and majority neighbors, causing it to oversample safe interior points instead of borderline ones (#235).
 
+* `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) with `all_neighbors = TRUE` now seeds synthetic points only from minority-class danger observations and takes a reduced step toward majority-class neighbors, matching borderline-SMOTE2. Previously it could seed from border-adjacent majority rows, generating minority-labeled points around majority centers (#242).
+
 * `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) was added. It cleans the data using the Edited Nearest Neighbors rule, removing observations whose class differs from the majority of their nearest neighbors (#115).

--- a/R/bsmote_impl.R
+++ b/R/bsmote_impl.R
@@ -103,8 +103,17 @@ bsmote_impl <- function(
     }
 
     if (all_neighbors) {
+      # borderline-SMOTE2 seeds from minority danger points but interpolates
+      # toward all neighbors, taking a reduced step toward majority neighbors.
       tmp_df <- as.data.frame(
-        smote_data(data_mat, k, samples_needed[i], which(danger_ids), distance)
+        smote_data(
+          data = data_mat,
+          k = k,
+          n_samples = samples_needed[i],
+          smote_ids = which(danger_ids & min_class_in),
+          distance = distance,
+          majority_neighbors = !min_class_in
+        )
       )
     } else {
       tmp_df <- as.data.frame(

--- a/R/smote_impl.R
+++ b/R/smote_impl.R
@@ -110,7 +110,8 @@ smote_data <- function(
   n_samples,
   smote_ids = seq_len(nrow(data)),
   distance = "euclidean",
-  step_size = 1
+  step_size = 1,
+  majority_neighbors = NULL
 ) {
   ids <- nn_indices(data, k, distance)
   indexes <- rep(sample(smote_ids), length.out = n_samples)
@@ -124,9 +125,16 @@ smote_data <- function(
     index_selection <- iii + seq_len(index_len[row_num])
     # removes itself as nearest neighbour
     id_knn <- ids[row_num, ids[row_num, ] != row_num]
-    dif <- data[id_knn[sampleids[index_selection]], ] -
-      data[rep(row_num, index_len[row_num]), ]
-    gap <- dif * runif_ids[index_selection] * step_size
+    selected <- id_knn[sampleids[index_selection]]
+    dif <- data[selected, ] - data[rep(row_num, index_len[row_num]), ]
+    step <- rep(step_size, length(index_selection))
+    if (!is.null(majority_neighbors)) {
+      # borderline-SMOTE2 halves the step toward majority-class neighbors so
+      # synthetic points stay closer to the minority seed.
+      step[majority_neighbors[selected]] <- step[majority_neighbors[selected]] *
+        0.5
+    }
+    gap <- dif * runif_ids[index_selection] * step
     out[index_selection, ] <- data[rep(row_num, index_len[row_num]), ] + gap
     iii <- iii + index_len[row_num]
   }

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -103,6 +103,34 @@ test_that("basic usage (all_neighbors = TRUE)", {
   expect_no_warning(prep(rec1))
 })
 
+test_that("all_neighbors = TRUE seeds only from minority rows (#242)", {
+  # A lone majority "bridge" point at x = 100 is a danger point (one minority
+  # neighbor), so the buggy code would seed synthetic minority points near it.
+  min_border <- data.frame(
+    x = c(0, 0.2, 0.4, 0.6, 0.8, 1),
+    y = 0,
+    class = "min"
+  )
+  maj_border <- data.frame(
+    x = c(0.1, 0.3, 0.5, 0.7, 0.9, 1.1),
+    y = 0,
+    class = "maj"
+  )
+  bridge_maj <- data.frame(x = 100, y = 0, class = "maj")
+  lone_min <- data.frame(x = 101, y = 0, class = "min")
+  maj_far <- data.frame(x = seq(200, 260, by = 3), y = 0, class = "maj")
+  df <- rbind(min_border, maj_border, bridge_maj, lone_min, maj_far)
+  df$class <- factor(df$class)
+
+  set.seed(42)
+  res <- bsmote(df, var = "class", k = 3, all_neighbors = TRUE)
+  new <- res[-seq_len(nrow(df)), ]
+
+  # With the bug the bridge point seeds synthetic points near x = 100; with the
+  # fix every point stays in the minority border region.
+  expect_lt(max(new$x), 2)
+})
+
 test_that("works with a single predictor (#151)", {
   skip_if_not_installed("modeldata")
 


### PR DESCRIPTION
With `all_neighbors = TRUE`, `bsmote()` selected its "danger" seeds over all rows, so border-adjacent majority rows could be used as centers for synthetic minority points. This restricts the seeds to minority-class danger observations and takes the paper's reduced (halved) step toward majority-class neighbors, so borderline-SMOTE2 now matches the reference algorithm. Fixes #242.