### PR TITLE
Correct page numbers for the ROSE R Journal reference

### DIFF
--- a/R/rose.R
+++ b/R/rose.R
@@ -64,7 +64,7 @@
 #' @template case-weights-not-supported
 #'
 #' @references Lunardon, N., Menardi, G., and Torelli, N. (2014). ROSE: a
-#'  Package for Binary Imbalanced Learning. R Journal, 6:82–92.
+#'  Package for Binary Imbalanced Learning. R Journal, 6:79–89.
 #' @references Menardi, G. and Torelli, N. (2014). Training and assessing
 #'  classification rules with imbalanced data. Data Mining and Knowledge
 #'  Discovery, 28:92–122.
@@ -343,7 +343,7 @@ required_pkgs.step_rose <- function(x, ...) {
 #' the underlying implementation, see that function's documentation.
 #'
 #' @references Lunardon, N., Menardi, G., and Torelli, N. (2014). ROSE: a
-#'  Package for Binary Imbalanced Learning. R Journal, 6:82–92.
+#'  Package for Binary Imbalanced Learning. R Journal, 6:79–89.
 #' @references Menardi, G. and Torelli, N. (2014). Training and assessing
 #'  classification rules with imbalanced data. Data Mining and Knowledge
 #'  Discovery, 28:92–122.

--- a/man/rose.Rd
+++ b/man/rose.Rd
@@ -70,7 +70,7 @@ rose(circle_example[, c("x", "y", "class")], var = "class", over_ratio = 0.8)
 }
 \references{
 Lunardon, N., Menardi, G., and Torelli, N. (2014). ROSE: a
-Package for Binary Imbalanced Learning. R Journal, 6:82–92.
+Package for Binary Imbalanced Learning. R Journal, 6:79–89.
 
 Menardi, G. and Torelli, N. (2014). Training and assessing
 classification rules with imbalanced data. Data Mining and Knowledge

--- a/man/step_rose.Rd
+++ b/man/step_rose.Rd
@@ -177,7 +177,7 @@ recipe(class ~ x + y, data = circle_example) |>
 }
 \references{
 Lunardon, N., Menardi, G., and Torelli, N. (2014). ROSE: a
-Package for Binary Imbalanced Learning. R Journal, 6:82–92.
+Package for Binary Imbalanced Learning. R Journal, 6:79–89.
 
 Menardi, G. and Torelli, N. (2014). Training and assessing
 classification rules with imbalanced data. Data Mining and Knowledge


### PR DESCRIPTION
The Lunardon, Menardi, and Torelli (2014) ROSE paper in the R Journal spans pages 79–89, not 82–92. Fixes the citation in the `rose()` and `step_rose()` references and their regenerated documentation.