### PR TITLE
Name step_upsample() in its ratio deprecation message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 * `step_svmsmote()` (and its direct-implementation counterpart `svmsmote()`) was added. It over-samples the minority classes near the decision boundary by fitting a support vector machine and generating new examples around the minority class support vectors, interpolating in dense regions and extrapolating in sparse ones (#170).
 
+* `step_upsample()` now names itself, rather than `step_downsample()`, in the deprecation message shown when the defunct `ratio` argument is supplied (#252).
+
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).
 
 * Added a new article explaining how `over_ratio` and `under_ratio` work (#141).

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -135,8 +135,8 @@ step_upsample <-
     if (lifecycle::is_present(ratio)) {
       lifecycle::deprecate_stop(
         "0.2.0",
-        "step_downsample(ratio = )",
-        "step_downsample(over_ratio = )"
+        "step_upsample(ratio = )",
+        "step_upsample(over_ratio = )"
       )
     }
 

--- a/tests/testthat/_snaps/upsample.md
+++ b/tests/testthat/_snaps/upsample.md
@@ -4,7 +4,7 @@
       new_rec <- step_upsample(recipe(~., data = circle_example), class, ratio = 2)
     Condition
       Error:
-      ! The `ratio` argument of `step_downsample()` was deprecated in themis 0.2.0 and is now defunct.
+      ! The `ratio` argument of `step_upsample()` was deprecated in themis 0.2.0 and is now defunct.
       i Please use the `over_ratio` argument instead.
 
 # bad data


### PR DESCRIPTION
Passing the defunct `ratio` argument to `step_upsample()` previously reported a deprecation message referring to `step_downsample()`. The `lifecycle::deprecate_stop()` call in `R/upsample.R` named the wrong function; it now names `step_upsample()`.

The existing snapshot test in `tests/testthat/test-upsample.R` has been updated to reflect the corrected message.

Closes #252