### PR TITLE
Validate step_rose() minority_prop with max = 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 
 * `step_rose()` and `rose()` now have improved documentation for `minority_prop`, clarifying that it controls the proportion of synthetic observations from the minority class, and how it differs from `over_ratio` (#144).
 
+* `step_rose()` (and its direct-implementation counterpart `rose()`) now validate that `minority_prop` is at most 1, since it is a proportion (#269).
+
 * Added standalone `rose()` function as a thin wrapper around `ROSE::ROSE()`, making it consistent with the other algorithms in the package that expose a direct implementation alongside their recipe step (#195).
 
 * `step_nearmiss()` and `step_tomek()` gain a `distance_with` argument to control which variables are used for distance calculations. This allows the steps to be used when non-numeric predictor variables are present in the data (#166).

--- a/R/rose.R
+++ b/R/rose.R
@@ -133,7 +133,7 @@ step_rose <-
     seed = sample.int(10^5, 1),
     id = rand_id("rose")
   ) {
-    check_number_decimal(minority_prop, min = 0)
+    check_number_decimal(minority_prop, min = 0, max = 1)
     check_number_decimal(minority_smoothness, min = 0)
     check_number_decimal(majority_smoothness, min = 0)
     check_number_whole(seed)
@@ -366,7 +366,7 @@ rose <- function(
   check_data_frame(df)
   check_var(var, df)
   check_number_decimal(over_ratio, min = 0)
-  check_number_decimal(minority_prop, min = 0)
+  check_number_decimal(minority_prop, min = 0, max = 1)
   check_number_decimal(minority_smoothness, min = 0)
   check_number_decimal(majority_smoothness, min = 0)
   check_2_levels_only(df, var)

--- a/tests/testthat/_snaps/rose.md
+++ b/tests/testthat/_snaps/rose.md
@@ -83,6 +83,14 @@
 ---
 
     Code
+      step_rose(recipe(~., data = mtcars), minority_prop = 1.5)
+    Condition
+      Error in `step_rose()`:
+      ! `minority_prop` must be a number between 0 and 1, not the number 1.5.
+
+---
+
+    Code
       step_rose(recipe(~., data = mtcars), minority_smoothness = TRUE)
     Condition
       Error in `step_rose()`:

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -276,6 +276,11 @@ test_that("bad args", {
   expect_snapshot(
     error = TRUE,
     recipe(~., data = mtcars) |>
+      step_rose(minority_prop = 1.5)
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., data = mtcars) |>
       step_rose(minority_smoothness = TRUE)
   )
   expect_snapshot(


### PR DESCRIPTION
`minority_prop` is ROSE's `p`, a probability, so it should be at most 1. Previously it was validated with `check_number_decimal(min = 0)` and accepted values above 1. This adds `max = 1` to the validation in both `step_rose()` and the direct-implementation `rose()`, so out-of-range values are rejected up front with a clear error.

Closes #269