### PR TITLE
Error early on degenerate outcome in step_smogn() auto-relevance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) was added. It over-samples rare regions of a numeric outcome for imbalanced regression using a combination of SMOTE-style interpolation and Gaussian noise, while under-sampling common regions (#49).
 
+* `step_smogn()` (and its direct-implementation counterpart `smogn()`) now emits a clear early error when automatic relevance is requested for a degenerate outcome (zero interquartile range or heavily tied values), pointing users to the `relevance` argument instead of aborting deep inside the boxplot-based computation (#264).
+
 * `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
 
 * `step_smotenc()` (and its direct-implementation counterpart `smotenc()`) now sets each synthetic sample's nominal features to the majority vote across the seed's k nearest neighbors, matching the SMOTENC algorithm, rather than voting over the randomly chosen interpolation partners (#241).

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -169,6 +169,19 @@ smogn_impl <- function(
 # monotone piecewise-cubic interpolation is used between them.
 smogn_relevance <- function(y, relevance = NULL, call = caller_env()) {
   if (is.null(relevance)) {
+    finite_y <- y[is.finite(y)]
+    if (length(unique(finite_y)) < 3 || stats::IQR(finite_y) == 0) {
+      cli::cli_abort(
+        c(
+          "Unable to determine rare values automatically for the outcome.",
+          i = "The outcome distribution is degenerate (zero \\
+          interquartile range or heavily tied values), so relevance \\
+          control points cannot be derived from its boxplot extremes.",
+          i = "Supply relevance control points via the {.arg relevance} argument."
+        ),
+        call = call
+      )
+    }
     stats <- grDevices::boxplot.stats(y)$stats
     med <- stats[3]
     cx <- med

--- a/tests/testthat/_snaps/smogn_impl.md
+++ b/tests/testthat/_snaps/smogn_impl.md
@@ -6,6 +6,26 @@
       Error in `smogn()`:
       ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
 
+# degenerate outcome errors during automatic relevance
+
+    Code
+      themis:::smogn_relevance(rep(0, 100))
+    Condition
+      Error:
+      ! Unable to determine rare values automatically for the outcome.
+      i The outcome distribution is degenerate (zero interquartile range or heavily tied values), so relevance control points cannot be derived from its boxplot extremes.
+      i Supply relevance control points via the `relevance` argument.
+
+---
+
+    Code
+      themis:::smogn_relevance(c(rep(0, 95), 1, 2, 3, 4, 5))
+    Condition
+      Error:
+      ! Unable to determine rare values automatically for the outcome.
+      i The outcome distribution is degenerate (zero interquartile range or heavily tied values), so relevance control points cannot be derived from its boxplot extremes.
+      i Supply relevance control points via the `relevance` argument.
+
 # smogn() interfaces correctly
 
     Code

--- a/tests/testthat/test-smogn_impl.R
+++ b/tests/testthat/test-smogn_impl.R
@@ -57,6 +57,15 @@ test_that("automatic relevance detects extremes", {
   expect_equal(phi[length(y)], 1)
 })
 
+test_that("degenerate outcome errors during automatic relevance", {
+  expect_snapshot(error = TRUE, {
+    themis:::smogn_relevance(rep(0, 100))
+  })
+  expect_snapshot(error = TRUE, {
+    themis:::smogn_relevance(c(rep(0, 95), 1, 2, 3, 4, 5))
+  })
+})
+
 test_that("smogn() interfaces correctly", {
   circle_numeric <- circle_example[, c("x", "y")]
 


### PR DESCRIPTION
When `relevance` is left `NULL`, `smogn_relevance()` derives control points from the boxplot whiskers of the outcome. A zero-inflated or heavily-tied outcome (e.g. many zeros) collapses those whiskers, so the function aborted deep inside the boxplot-based computation with an opaque message.

This adds an early check for a degenerate outcome distribution (fewer than three unique finite values, or a zero interquartile range) before automatic relevance is computed, and emits a clear cli error steering the user to supply the `relevance` argument.

Closes #264