### PR TITLE
Key downsample/upsample baking off column value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,8 @@
 
 * `step_bsmote()` now works correctly when there is only a single predictor (#151).
 
+* `step_downsample()` and `step_upsample()` now key baking off the selected column value rather than its name, matching the other steps (#272).
+
 * `step_downsample()` and `step_upsample()` now correctly handle `NA` values in the outcome variable instead of erroring (#177).
 
 # themis 1.0.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,8 +60,6 @@
 
 * `step_bsmote()` now works correctly when there is only a single predictor (#151).
 
-* `step_downsample()` and `step_upsample()` now key baking off the selected column value rather than its name, matching the other steps (#272).
-
 * `step_downsample()` and `step_upsample()` now correctly handle `NA` values in the outcome variable instead of erroring (#177).
 
 # themis 1.0.3

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -247,7 +247,7 @@ subsamp <- function(x, wts, num) {
 
 #' @export
 bake.step_downsample <- function(object, new_data, ...) {
-  col_names <- names(object$column)
+  col_names <- object$column
   check_new_data(col_names, object, new_data)
 
   if (length(col_names) == 0L) {

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -273,7 +273,7 @@ supsamp_with_indicator <- function(x, wts, num) {
 
 #' @export
 bake.step_upsample <- function(object, new_data, ...) {
-  col_names <- names(object$column)
+  col_names <- object$column
   check_new_data(col_names, object, new_data)
 
   if (length(col_names) == 0L) {

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -305,6 +305,16 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("baking works on new_data (keys off column value)", {
+  rec <- recipe(~., data = circle_example) |>
+    step_downsample(class) |>
+    prep()
+
+  res <- bake(rec, new_data = circle_example)
+
+  expect_equal(sort(table(res$class)), sort(table(circle_example$class)))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -336,6 +336,17 @@ test_that("unused outcome levels are skipped with a warning (#238)", {
   expect_gt(nrow(res), 0)
 })
 
+test_that("baking works on new_data (keys off column value)", {
+  rec <- recipe(~., data = circle_example) |>
+    step_upsample(class) |>
+    prep()
+
+  res <- bake(rec, new_data = circle_example)
+
+  expect_gt(nrow(res), 0)
+  expect_true("class" %in% names(res))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
`bake.step_downsample()` and `bake.step_upsample()` keyed off `names(object$column)` rather than the value `object$column`, unlike every other step. This only worked because `recipes_eval_select()` currently returns a named vector where the name equals the value. This changes both to use `object$column` directly for consistency. The change is behavior-preserving; a regression test was added to each step's test file confirming baking still works.

Closes #272