### PR TITLE
Leave over-target classes untouched in step_upsample() (#263)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,8 @@
 
 * `step_downsample()` and `step_upsample()` now correctly handle `NA` values in the outcome variable instead of erroring (#177).
 
+* `step_upsample()` now leaves classes that already meet or exceed the target size untouched instead of resampling them with replacement, and produces the same rows whether or not `indicator_column` is set (#263).
+
 # themis 1.0.3
 
 ## Improvements

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -247,13 +247,12 @@ supsamp <- function(x, wts, num) {
   if (n == 0) {
     return(x)
   }
-  if (nrow(x) == num) {
-    out <- x
-  } else {
-    # upsampling is done with replacement
-    out <- x[sample(seq_len(n), max(num, n), replace = TRUE, prob = wts), ]
+  if (n >= num) {
+    return(x)
   }
-  out
+  # upsampling keeps all originals and appends duplicates drawn with replacement
+  extra_idx <- sample(seq_len(n), num - n, replace = TRUE, prob = wts)
+  rbind(x, x[extra_idx, ])
 }
 
 supsamp_with_indicator <- function(x, wts, num) {

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -347,6 +347,43 @@ test_that("baking works on new_data (keys off column value)", {
   expect_true("class" %in% names(res))
 })
 
+test_that("classes above target are left unchanged when over_ratio < 1 (#263)", {
+  res <- recipe(class ~ x + y, data = circle_example) |>
+    step_upsample(class, over_ratio = 0.5) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  majority <- names(which.max(table(circle_example$class)))
+  orig <- circle_example[circle_example$class == majority, c("x", "y")]
+  kept <- as.data.frame(res[res$class == majority, c("x", "y")])
+
+  expect_equal(nrow(kept), nrow(orig))
+  expect_equal(
+    kept[order(kept$x, kept$y), ],
+    orig[order(orig$x, orig$y), ],
+    ignore_attr = TRUE
+  )
+})
+
+test_that("indicator and non-indicator paths keep the same originals (#263)", {
+  set.seed(1)
+  res_plain <- recipe(class ~ x + y, data = circle_example) |>
+    step_upsample(class, over_ratio = 0.5) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  set.seed(1)
+  res_ind <- recipe(class ~ x + y, data = circle_example) |>
+    step_upsample(class, over_ratio = 0.5, indicator_column = ".new_row") |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(
+    as.data.frame(res_plain),
+    as.data.frame(res_ind[, c("x", "y", "class")])
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
## Problem

In `supsamp()`, `step_upsample()` used `sample(seq_len(n), max(num, n), replace = TRUE, prob = wts)`. When a class already met or exceeded the target size (`n >= num`), `max(num, n) == n`, so the class was resampled to its own size with replacement: some rows duplicated, some dropped, count unchanged. This contradicts the documentation, which promises such classes "are left alone". It surfaces when `over_ratio < 1`.

Separately, the non-indicator path full-bootstrapped the class while `supsamp_with_indicator()` kept all originals and appended only the needed duplicates. Toggling `indicator_column` therefore changed which rows were produced for the same seed.

## Fix

`supsamp()` now early-returns untouched classes (`if (n >= num) return(x)`) and, when upsampling is needed, keeps all originals and appends only the `num - n` extra rows drawn with replacement. This matches `supsamp_with_indicator()`, so both paths agree for a fixed seed.

## Tests

Added two tests in `test-upsample.R`: a class above target is left unchanged when `over_ratio < 1`, and the indicator vs non-indicator paths keep the same originals for a fixed seed.

Closes #263