### PR TITLE
Round fractional over_ratio target (#248)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * All sampling steps now handle an unused (zero-count) factor level in the outcome gracefully, dropping it with a warning before computing sampling targets instead of deleting all rows or erroring (#238).
 
+* `step_smote()`, `step_adasyn()`, `step_bsmote()`, `step_svmsmote()`, `step_smoten()`, and `step_smotenc()` (and their direct-implementation counterparts) now round the fractional oversampling target instead of truncating it, so a fractional `over_ratio` lands on the nearest integer count (#248).
+
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) now weights minority observations by their exact majority-neighbor count. An off-by-one subtraction previously undercounted majority neighbors, zeroing out the weight of border points with a single majority neighbor and biasing sampling away from the class boundary (#239).
 
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) no longer errors with a cryptic message when a minority class is well separated from the majority classes; it now falls back to uniform sampling and checks the minority class size before sampling (#240).

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -61,7 +61,7 @@ adasyn_impl <- function(
   df[[var]] <- as.factor(df[[var]])
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
-  ratio_target <- majority_count * over_ratio
+  ratio_target <- round(majority_count * over_ratio)
   which_upsample <- which(counts < ratio_target)
   samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)

--- a/R/bsmote_impl.R
+++ b/R/bsmote_impl.R
@@ -77,7 +77,7 @@ bsmote_impl <- function(
   df[[var]] <- as.factor(df[[var]])
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
-  ratio_target <- majority_count * over_ratio
+  ratio_target <- round(majority_count * over_ratio)
   which_upsample <- which(counts < ratio_target)
   samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)

--- a/R/smote_impl.R
+++ b/R/smote_impl.R
@@ -62,7 +62,7 @@ smote_impl <- function(
   data <- split(df, df[[var]])
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
-  ratio_target <- majority_count * over_ratio
+  ratio_target <- round(majority_count * over_ratio)
   which_upsample <- which(counts < ratio_target)
   samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)

--- a/R/smoten_impl.R
+++ b/R/smoten_impl.R
@@ -63,7 +63,7 @@ smoten_impl <- function(df, var, k, over_ratio, call = caller_env()) {
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
   # How many minority samples do we want in total?
-  ratio_target <- majority_count * over_ratio
+  ratio_target <- round(majority_count * over_ratio)
   # Which classes need upsampling
   which_upsample <- which(counts < ratio_target)
   # For each minority class, determine how many more samples are needed

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -57,7 +57,7 @@ smotenc_impl <- function(df, var, k, over_ratio, call = caller_env()) {
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
   # How many minority samples do we want in total?
-  ratio_target <- majority_count * over_ratio
+  ratio_target <- round(majority_count * over_ratio)
   # How many classes do we need to upsample (account for 2+ classes!)
   # Get the indices of those classes
   which_upsample <- which(counts < ratio_target)

--- a/R/svmsmote_impl.R
+++ b/R/svmsmote_impl.R
@@ -69,7 +69,7 @@ svmsmote_impl <- function(
 
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)
-  ratio_target <- majority_count * over_ratio
+  ratio_target <- round(majority_count * over_ratio)
   which_upsample <- which(counts < ratio_target)
   samples_needed <- ratio_target - counts[which_upsample]
   min_names <- names(samples_needed)

--- a/tests/testthat/test-adasyn_impl.R
+++ b/tests/testthat/test-adasyn_impl.R
@@ -163,6 +163,17 @@ test_that("adasyn() interfaces correctly", {
   )
 })
 
+test_that("fractional over_ratio target is rounded (#248)", {
+  df <- data.frame(
+    x = rnorm(90),
+    y = rnorm(90),
+    class = factor(rep(c("min", "maj"), c(10, 80)))
+  )
+  # round(80 * 0.383) == 31, truncation would give 30
+  result <- adasyn(df, var = "class", k = 5, over_ratio = 0.383)
+  expect_equal(sum(result$class == "min"), 31)
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-bsmote_impl.R
+++ b/tests/testthat/test-bsmote_impl.R
@@ -181,6 +181,12 @@ test_that("bsmote() interfaces correctly", {
   )
 })
 
+test_that("fractional over_ratio target is rounded (#248)", {
+  # round(342 * 0.502) == 172, truncation would give 171
+  result <- bsmote(circle_example_num, var = "class", over_ratio = 0.502)
+  expect_equal(sum(result$class == "Circle"), 172)
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-smote_impl.R
+++ b/tests/testthat/test-smote_impl.R
@@ -180,6 +180,16 @@ test_that("Doesn't error if no upsampling is done (#119)", {
   )
 })
 
+test_that("fractional over_ratio target is rounded (#248)", {
+  df <- data.frame(
+    x = rnorm(90),
+    class = factor(rep(c("min", "maj"), c(10, 80)))
+  )
+  # round(80 * 0.383) == 31, truncation would give 30
+  result <- smote_impl(df, "class", 5, over_ratio = 0.383)
+  expect_equal(sum(result$class == "min"), 31)
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-smoten_impl.R
+++ b/tests/testthat/test-smoten_impl.R
@@ -21,6 +21,16 @@ test_that("generated values only use existing category levels", {
   expect_true(all(as.character(result$x) %in% letters[1:3]))
 })
 
+test_that("fractional over_ratio target is rounded (#248)", {
+  df <- data.frame(
+    x = factor(sample(letters[1:3], 95, replace = TRUE)),
+    class = factor(rep(c("min", "maj"), c(15, 80)))
+  )
+  # round(80 * 0.383) == 31, truncation would give 30
+  result <- smoten(df, var = "class", k = 5, over_ratio = 0.383)
+  expect_equal(sum(result$class == "min"), 31)
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-smotenc_impl.R
+++ b/tests/testthat/test-smotenc_impl.R
@@ -39,6 +39,17 @@ test_that("categorical vote uses all k neighbors, not the chosen partner", {
   expect_all_equal(as.character(synthetic$cat), "a")
 })
 
+test_that("fractional over_ratio target is rounded (#248)", {
+  df <- data.frame(
+    x = rnorm(95),
+    cat = factor(sample(letters[1:3], 95, replace = TRUE)),
+    class = factor(rep(c("min", "maj"), c(15, 80)))
+  )
+  # round(80 * 0.383) == 31, truncation would give 30
+  result <- smotenc(df, var = "class", k = 5, over_ratio = 0.383)
+  expect_equal(sum(result$class == "min"), 31)
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -178,6 +178,18 @@ test_that("ratio value works when oversampling", {
   )
 })
 
+test_that("fractional over_ratio target is rounded (#248)", {
+  skip_if_not_installed("kernlab")
+
+  # round(342 * 0.502) == 172, truncation would give 171
+  res <- recipe(class ~ x + y, data = circle_example) |>
+    step_svmsmote(class, over_ratio = 0.502) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(sum(res$class == "Circle"), 172)
+})
+
 test_that("factor levels are not affected by alphabet ordering or class sizes", {
   skip_if_not_installed("kernlab")
 


### PR DESCRIPTION
Fractional `over_ratio` was silently truncated because `majority_count * over_ratio` was used directly as the target count. For example `over_ratio = 0.377` on 80 majority observations targeted 30 instead of 30.16.

This wraps the target computation in `round()` (nearest integer) in all six SMOTE-family implementations that share the `ratio_target <- majority_count * over_ratio` pattern: `smote`, `adasyn`, `bsmote`, `svmsmote`, `smoten`, and `smotenc`. Added a fractional-`over_ratio` test to each that lands on a non-integer target and asserts the rounded count.

Closes #248