### PR TITLE
Remove only the majority-class member of each Tomek link (#262)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 
 * `step_smotenc()` (and its direct-implementation counterpart `smotenc()`) now sets each synthetic sample's nominal features to the majority vote across the seed's k nearest neighbors, matching the SMOTENC algorithm, rather than voting over the randomly chosen interpolation partners (#241).
 
+* `step_tomek()` (and its direct-implementation counterpart `tomek()`) now removes only the majority-class member of each Tomek link, retaining the minority-class member, matching the documented behavior. Previously it removed both members of the pair (#262).
+
 * `step_svmsmote()` (and its direct-implementation counterpart `svmsmote()`) was added. It over-samples the minority classes near the decision boundary by fitting a support vector machine and generating new examples around the minority class support vectors, interpolating in dense regions and extrapolating in sparse ones (#170).
 
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).

--- a/R/tomek_impl.R
+++ b/R/tomek_impl.R
@@ -1,6 +1,7 @@
 #' Remove Tomek's links
 #'
-#' Removed observations that are part of tomek links.
+#' Removes the majority class member of each pair of observations that form a
+#' Tomek link.
 #'
 #' @param df data.frame or tibble. Must have 1 factor variable and remaining
 #'  numeric variables.
@@ -47,6 +48,7 @@ tomek_impl <- function(df, var, distance = "euclidean") {
 
   remove <- logical(nrow(df))
   outcome <- df[[var]]
+  class_sizes <- table(outcome)
 
   for (class in unique(outcome)) {
     target <- which(outcome == class)
@@ -55,8 +57,15 @@ tomek_impl <- function(df, var, distance = "euclidean") {
 
     tomek <- target == neighbor_neighbor & outcome[target] != outcome[neighbor]
 
-    tomek_links <- c(target[tomek], neighbor[tomek])
-    remove[tomek_links] <- TRUE
+    target_link <- target[tomek]
+    neighbor_link <- neighbor[tomek]
+
+    # Remove only the majority-class member of each Tomek link
+    target_is_majority <-
+      class_sizes[as.character(outcome[target_link])] >=
+        class_sizes[as.character(outcome[neighbor_link])]
+
+    remove[ifelse(target_is_majority, target_link, neighbor_link)] <- TRUE
   }
 
   which(remove)

--- a/man/tomek.Rd
+++ b/man/tomek.Rd
@@ -24,7 +24,8 @@ large datasets.}
 A data.frame or tibble, depending on type of \code{df}.
 }
 \description{
-Removed observations that are part of tomek links.
+Removes the majority class member of each pair of observations that form a
+Tomek link.
 }
 \details{
 A Tomek link is a pair of points from different classes that are each

--- a/tests/testthat/test-tomek_impl.R
+++ b/tests/testthat/test-tomek_impl.R
@@ -25,11 +25,12 @@ test_that("tomek removes exactly the points forming Tomek links", {
     class = factor(c("min", "maj", "min", "maj", "maj"))
   )
   result <- tomek(df, var = "class")
-  # Pair {1, 2}: mutual NN, different class → Tomek link, both removed
-  # Point 3: NN is point 2, but point 2's NN is point 1 → not a link
-  # Pair {4, 5}: mutual NN, same class → not a link
-  expect_equal(result$x, c(3, 10, 11))
-  expect_equal(as.character(result$class), c("min", "maj", "maj"))
+  # Pair {1, 2}: mutual NN, different class -> Tomek link, majority (maj)
+  #   member (point 2) removed, minority (min) member (point 1) retained
+  # Point 3: NN is point 2, but point 2's NN is point 1 -> not a link
+  # Pair {4, 5}: mutual NN, same class -> not a link
+  expect_equal(result$x, c(0, 3, 10, 11))
+  expect_equal(as.character(result$class), c("min", "min", "maj", "maj"))
 })
 
 test_that("order doesn't matter", {
@@ -37,13 +38,13 @@ test_that("order doesn't matter", {
     target = rep(c("Yes", "No"), c(10, 50)),
     x = rep(c(1, 2, 3), c(9, 2, 49))
   )
-  expect_equal(c(10, 11), themis:::tomek_impl(df, "target"))
+  expect_equal(11, themis:::tomek_impl(df, "target"))
 
   df <- data.frame(
     target = rep(c("Yes", "No"), c(50, 10)),
     x = rep(c(1, 2, 3), c(49, 2, 9))
   )
-  expect_equal(c(50, 51), themis:::tomek_impl(df, "target"))
+  expect_equal(50, themis:::tomek_impl(df, "target"))
 })
 
 


### PR DESCRIPTION
`step_tomek()` (and its direct-implementation `tomek()`) removed both members of each Tomek link, but the documentation promised that only the majority-class instance is removed. This restricts removal to the majority-class member of each pair, retaining the minority-class member, so the code matches the docs.

Changes:
- `tomek_impl()` now determines which member of each link belongs to the larger (majority) class and drops only that one.
- Updated the `tomek()` roxygen description to describe majority-only removal.
- Updated tests in `test-tomek_impl.R` to assert minority members are retained.
- Added a `NEWS.md` bullet.

Closes #262