### PR TITLE
Validate step_rose() predictor types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,8 @@
 
 * All upsampling steps gain an `indicator_column` argument. When set, a logical column is added to the baked data marking rows added by the step (`TRUE`) vs rows from the original data (`FALSE`). For `step_rose()`, all rows are `TRUE` since ROSE generates a fully synthetic dataset (#58).
 
+* `step_rose()` now validates predictor types during `prep()`, giving a clear error for unsupported types consistent with the other sampling steps instead of relying on `ROSE::ROSE()` to fail downstream (#265).
+
 * `step_rose()` and `rose()` now have improved documentation for `minority_prop`, clarifying that it controls the proportion of synthetic observations from the minority class, and how it differs from `over_ratio` (#144).
 
 * Added standalone `rose()` function as a thin wrapper around `ROSE::ROSE()`, making it consistent with the other algorithms in the package that expose a direct implementation alongside their recipe step (#195).

--- a/R/rose.R
+++ b/R/rose.R
@@ -212,7 +212,9 @@ prep.step_rose <- function(x, training, info = NULL, ...) {
   )
 
   predictors <- setdiff(recipes::recipes_names_predictors(info), col_name)
-  check_na(select(training, all_of(col_name)))
+
+  check_type(training[, predictors], types = c("double", "integer", "nominal"))
+  check_na(select(training, all_of(c(col_name, predictors))))
 
   step_rose_new(
     terms = x$terms,

--- a/tests/testthat/_snaps/rose.md
+++ b/tests/testthat/_snaps/rose.md
@@ -16,6 +16,16 @@
       Caused by error in `prep()`:
       ! The selector should select at most a single variable.
 
+# errors on unsupported predictor types
+
+    Code
+      prep(step_rose(recipe(x ~ y, data = df_date), x))
+    Condition
+      Error in `step_rose()`:
+      Caused by error in `prep()`:
+      x All columns selected for the step should be double, integer, or nominal.
+      * 1 date variable found: `y`
+
 # NA in response
 
     Code

--- a/tests/testthat/test-rose.R
+++ b/tests/testthat/test-rose.R
@@ -82,6 +82,20 @@ test_that("bad data", {
   )
 })
 
+test_that("errors on unsupported predictor types", {
+  df_date <- data.frame(
+    x = factor(rep(c("a", "b"), c(2, 8))),
+    y = as.Date("2020-01-01") + 1:10
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(x ~ y, data = df_date) |>
+      step_rose(x) |>
+      prep()
+  )
+})
+
 test_that("NA in response", {
   skip_if_not_installed("modeldata")
 


### PR DESCRIPTION
`step_rose()` was the only over-sampler that did not validate its predictors during `prep()`; it ran `check_na()` only on the outcome and relied on `ROSE::ROSE()` to error downstream, producing a less informative message than the SMOTE-family steps.

This adds a `check_type()` call on `c(column, predictors)` and extends the NA check to the predictors, matching the convention used elsewhere in the package. Because `ROSE::ROSE()` genuinely supports categorical predictors (existing tests exercise a character predictor), the allowed types are `double`, `integer`, and `nominal` rather than the numeric-only set used by SMOTE. Unsupported types (e.g. dates) now get a clear error at `prep()`.

Closes #265