### PR TITLE
Return true cosine-distance magnitudes for nearmiss and smogn (#244)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 * `step_nearmiss()` (and its direct-implementation counterpart `nearmiss()`) now keeps the majority observations that are genuinely closest to the minority class, rather than selecting rows by their position in the data (#236).
 
+* `step_nearmiss()` and `step_smogn()` (and their direct-implementation counterparts `nearmiss()` and `smogn()`) now return true cosine-distance magnitudes with `distance = "cosine"`. Previously the cosine branch L2-normalized and took Euclidean distances, returning `sqrt(2 - 2 * cos_sim)` instead of `1 - cos_sim`. Neighbor ordering was unaffected, but NearMiss neighbor-distance averages and SMOGN's interpolate-vs-noise threshold used the wrong magnitudes (#244).
+
 * `step_oss()` (and its direct-implementation counterpart `oss()`) was added. It under-samples the majority classes using One-Sided Selection, combining Condensed Nearest Neighbors to reduce redundant majority class observations with Tomek's links to remove majority class observations on the decision boundary (#114).
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) was added. It over-samples rare regions of a numeric outcome for imbalanced regression using a combination of SMOTE-style interpolation and Gaussian noise, while under-sampling common regions (#49).

--- a/R/misc.R
+++ b/R/misc.R
@@ -224,7 +224,11 @@ nn_dists_cross <- function(query, reference, k, distance) {
     norms_ref[norms_ref == 0] <- 1
     norms_qry <- sqrt(rowSums(query^2))
     norms_qry[norms_qry == 0] <- 1
-    return(RANN::nn2(reference / norms_ref, query / norms_qry, k = k)$nn.dists)
+    # RANN returns Euclidean distances between unit vectors, sqrt(2 - 2*cos).
+    # Convert to cosine distance (1 - cos_sim = d^2 / 2) so magnitudes are
+    # correct for consumers such as NearMiss that average per-neighbor values.
+    d <- RANN::nn2(reference / norms_ref, query / norms_qry, k = k)$nn.dists
+    return(d^2 / 2)
   }
   if (distance == "mahalanobis") {
     if (nrow(reference) <= ncol(reference)) {

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -213,7 +213,11 @@ smogn_distmat <- function(data, distance) {
   if (distance == "cosine") {
     norms <- sqrt(rowSums(data^2))
     norms[norms == 0] <- 1
-    return(as.matrix(stats::dist(data / norms)))
+    # Euclidean distance between unit vectors is sqrt(2 - 2*cos); convert to
+    # cosine distance (1 - cos_sim = d^2 / 2) so the interpolate-vs-noise test
+    # compares true cosine-distance magnitudes.
+    d <- as.matrix(stats::dist(data / norms))
+    return(d^2 / 2)
   }
   if (distance == "mahalanobis") {
     S <- stats::cov(data)

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -44,6 +44,18 @@ test_that("nn_indices() uses the correct distance metric", {
   expect_equal(nn1(nn_indices(data_mahal, 1, "mahalanobis"), 1), 3L)
 })
 
+test_that("nn_dists_cross() returns cosine-distance magnitudes 1 - cos_sim (#244)", {
+  query <- matrix(c(1, 0, 1, 1), ncol = 2, byrow = TRUE)
+  reference <- matrix(c(0, 1, 2, 0, 3, 3), ncol = 2, byrow = TRUE)
+
+  cos_sim <- (query / sqrt(rowSums(query^2))) %*%
+    t(reference / sqrt(rowSums(reference^2)))
+  expected <- t(apply(1 - cos_sim, 1, sort))
+
+  d <- nn_dists_cross(query, reference, k = 3, distance = "cosine")
+  expect_equal(d, expected)
+})
+
 test_that("mahalanobis whitening reproduces stats::mahalanobis distances (#237)", {
   set.seed(1)
   n <- 200


### PR DESCRIPTION
## Problem

With `distance = "cosine"`, the nearest-neighbor helpers L2-normalized the data and then took Euclidean distances, returning `sqrt(2 - 2 * cos_sim)`. This is monotone in cosine distance, so any consumer that only uses neighbor *ordering* or *indices* was correct. But consumers that use the distance *magnitude* were wrong:

- `nearmiss()` averages k per-neighbor distances.
- `smogn()`'s `d < 0.5 * median(kNN)` interpolate-vs-noise test flips on the wrong scale.

## Fix

The Euclidean distance between two unit vectors is `sqrt(2 - 2 * cos_sim)`, so cosine distance `1 - cos_sim = d^2 / 2`. The two magnitude-returning cosine branches now apply this conversion:

- `nn_dists_cross()` in `R/misc.R`
- `smogn_distmat()` in `R/smogn_impl.R`

The index/ordering branches (`nn_indices()`, `nn_indices_cross()`) are left unchanged since the transform is monotone.

## Tests

Added a test asserting `nn_dists_cross()` cosine magnitudes equal `1 - cos_sim` for known vectors. Full test suite passes with no snapshot changes.

Closes #244