### PR TITLE
Error when over-samplers receive case weights (#243)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # themis (development version)
 
+* Over-sampling steps (`step_smote()`, `step_adasyn()`, `step_bsmote()`, `step_svmsmote()`, `step_smoten()`, `step_smotenc()`, `step_rose()`, and `step_smogn()`) now error when supplied a case weights column instead of silently filling synthetic rows' weights with `NA`. These steps have never supported case weights (#243).
+
 * All sampling steps now handle an unused (zero-count) factor level in the outcome gracefully, dropping it with a warning before computing sampling targets instead of deleting all rows or erroring (#238).
 
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) now weights minority observations by their exact majority-neighbor count. An off-by-one subtraction previously undercounted majority neighbors, zeroing out the weight of border points with a single majority neighbor and biasing sampling away from the class boundary (#239).

--- a/R/misc.R
+++ b/R/misc.R
@@ -141,7 +141,25 @@ add_indicator_column <- function(new_data, n_orig, indicator_column) {
   new_data
 }
 
-na_splice <- function(new_data, synthetic_data, object) {
+check_case_weights_not_supported <- function(data, call = caller_env()) {
+  has_weights <- vapply(data, hardhat::is_case_weights, logical(1))
+  if (any(has_weights)) {
+    cols <- names(has_weights)[has_weights]
+    cli::cli_abort(
+      c(
+        "This step does not support case weights.",
+        i = "The case weights column{?s} {.var {cols}} must be removed \\
+             before this step."
+      ),
+      call = call
+    )
+  }
+  invisible()
+}
+
+na_splice <- function(new_data, synthetic_data, object, call = caller_env()) {
+  check_case_weights_not_supported(new_data, call = call)
+
   non_predictor <- setdiff(names(new_data), c(object$column, object$predictors))
 
   if (length(non_predictor) == 0) {

--- a/R/smogn.R
+++ b/R/smogn.R
@@ -218,6 +218,8 @@ bake.step_smogn <- function(object, new_data, ...) {
     return(new_data)
   }
 
+  check_case_weights_not_supported(new_data)
+
   ignore_vars <- setdiff(names(new_data), col_names)
   new_data <- as.data.frame(new_data)
 

--- a/man-roxygen/case-weights-not-supported.R
+++ b/man-roxygen/case-weights-not-supported.R
@@ -1,3 +1,4 @@
 #' @section Case weights:
 #'
-#' The underlying operation does not allow for case weights.
+#' The underlying operation does not allow for case weights. Supplying data
+#' with a case weights column to this step results in an error.

--- a/man/step_adasyn.Rd
+++ b/man/step_adasyn.Rd
@@ -128,7 +128,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_bsmote.Rd
+++ b/man/step_bsmote.Rd
@@ -144,7 +144,8 @@ This step has 3 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_cnn.Rd
+++ b/man/step_cnn.Rd
@@ -111,7 +111,8 @@ columns \code{terms} and \code{id}:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -134,7 +134,8 @@ This step has 1 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_instance_hardness.Rd
+++ b/man/step_instance_hardness.Rd
@@ -124,7 +124,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_ncl.Rd
+++ b/man/step_ncl.Rd
@@ -125,7 +125,8 @@ This step has 1 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_nearmiss.Rd
+++ b/man/step_nearmiss.Rd
@@ -126,7 +126,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_oss.Rd
+++ b/man/step_oss.Rd
@@ -108,7 +108,8 @@ columns \code{terms} and \code{id}:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_rose.Rd
+++ b/man/step_rose.Rd
@@ -125,7 +125,8 @@ This step has 1 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_smogn.Rd
+++ b/man/step_smogn.Rd
@@ -130,7 +130,8 @@ This step has 1 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_smote.Rd
+++ b/man/step_smote.Rd
@@ -126,7 +126,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_smoten.Rd
+++ b/man/step_smoten.Rd
@@ -117,7 +117,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_smotenc.Rd
+++ b/man/step_smotenc.Rd
@@ -120,7 +120,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_svmsmote.Rd
+++ b/man/step_svmsmote.Rd
@@ -141,7 +141,8 @@ This step has 2 tuning parameters:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/man/step_tomek.Rd
+++ b/man/step_tomek.Rd
@@ -103,7 +103,8 @@ columns \code{terms} and \code{id}:
 \section{Case weights}{
 
 
-The underlying operation does not allow for case weights.
+The underlying operation does not allow for case weights. Supplying data
+with a case weights column to this step results in an error.
 }
 
 \examples{

--- a/tests/testthat/_snaps/smote.md
+++ b/tests/testthat/_snaps/smote.md
@@ -119,6 +119,17 @@
       Unused factor level "unused" in `class` was dropped.
       i  Level with zero observations is skipped when computing sampling targets.
 
+# step_smote() errors with case weights (#243)
+
+    Code
+      bake(prep(step_smote(recipe(class ~ ., data = df), class, skip = FALSE)),
+      new_data = NULL)
+    Condition
+      Error in `step_smote()`:
+      Caused by error in `bake()`:
+      ! This step does not support case weights.
+      i The case weights column `wts` must be removed before this step.
+
 # bake method errors when needed non-standard role columns are missing
 
     Code

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -397,6 +397,19 @@ test_that("smote() works with a character `var` (#261)", {
   expect_identical(sum(is.na(res$class)), 0L)
 })
 
+test_that("step_smote() errors with case weights (#243)", {
+  df <- circle_example[c("x", "y", "class")]
+  df$wts <- hardhat::frequency_weights(rep(1L, nrow(df)))
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ ., data = df) |>
+      step_smote(class, skip = FALSE) |>
+      prep() |>
+      bake(new_data = NULL)
+  )
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {


### PR DESCRIPTION
## Problem

The roxygen template `man-roxygen/case-weights-not-supported.R` documents over-samplers as not supporting case weights, but only `step_downsample()` / `step_upsample()` actually handle them. Every over-sampler treated a `hardhat::frequency_weights` / `importance_weights` column as a generic non-predictor, so the shared `na_splice()` helper silently filled synthetic rows' weights with `NA`.

## Change

Over-sampling steps now error when supplied a case weights column instead of silently injecting `NA`. A new `check_case_weights_not_supported()` helper detects a hardhat case-weights column and aborts with a clear cli error. It is invoked in the shared `na_splice()` path (covering smote, adasyn, bsmote, svmsmote, smoten, smotenc, rose) and directly in `bake.step_smogn()` (which does not route through `na_splice()`).

`step_downsample()` and `step_upsample()` are unaffected: they have their own case-weight handling and do not route through `na_splice()`.

- Added a snapshot test in `test-smote.R`.
- Updated the roxygen template and re-documented.
- Added a `NEWS.md` bullet.

Closes #243