### PR TITLE
Align SMOGN noise, OSS condensation, and NCL tie with their reference papers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,15 +28,21 @@
 
 * `step_ncl()` (and its direct-implementation counterpart `ncl()`) was added. It cleans the data using the Neighborhood Cleaning Rule, removing majority class observations that are noisy or that pollute the neighborhood of minority class observations (#116).
 
+* `step_ncl()` (and its direct-implementation counterpart `ncl()`) now treats a majority class whose size is exactly `threshold_clean` times the minority size as eligible for cleaning, using the `>=` comparison from Laurikkala (2001) instead of a strict `>` (#250).
+
 * `step_nearmiss()` (and its direct-implementation counterpart `nearmiss()`) now keeps the majority observations that are genuinely closest to the minority class, rather than selecting rows by their position in the data (#236).
 
 * `step_nearmiss()` and `step_smogn()` (and their direct-implementation counterparts `nearmiss()` and `smogn()`) now return true cosine-distance magnitudes with `distance = "cosine"`. Previously the cosine branch L2-normalized and took Euclidean distances, returning `sqrt(2 - 2 * cos_sim)` instead of `1 - cos_sim`. Neighbor ordering was unaffected, but NearMiss neighbor-distance averages and SMOGN's interpolate-vs-noise threshold used the wrong magnitudes (#244).
 
 * `step_oss()` (and its direct-implementation counterpart `oss()`) was added. It under-samples the majority classes using One-Sided Selection, combining Condensed Nearest Neighbors to reduce redundant majority class observations with Tomek's links to remove majority class observations on the decision boundary (#114).
 
+* `step_oss()` (and its direct-implementation counterpart `oss()`) now condenses the majority classes with a single pass, matching Kubat & Matwin (1997), instead of iterating Condensed Nearest Neighbors to convergence, which removed more observations than the reference (#250).
+
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) was added. It over-samples rare regions of a numeric outcome for imbalanced regression using a combination of SMOTE-style interpolation and Gaussian noise, while under-sampling common regions (#49).
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) now emits a clear early error when automatic relevance is requested for a degenerate outcome (zero interquartile range or heavily tied values), pointing users to the `relevance` argument instead of aborting deep inside the boxplot-based computation (#264).
+
+* `step_smogn()` (and its direct-implementation counterpart `smogn()`) now scales the Gaussian perturbation of unsafe cases by each feature's standard deviation and caps the perturbation amount at the safe distance, using `sd * min(perturbation, maxD)` as in the reference, instead of scaling by a distance-capped standard deviation (#250).
 
 * `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
 

--- a/R/ncl_impl.R
+++ b/R/ncl_impl.R
@@ -88,7 +88,7 @@ ncl_impl <- function(
 
   # Majority classes large enough to be cleaned around minority observations.
   classes_to_clean <- setdiff(
-    names(counts)[counts > minority_count * threshold_clean],
+    names(counts)[counts >= minority_count * threshold_clean],
     minority
   )
 

--- a/R/oss_impl.R
+++ b/R/oss_impl.R
@@ -54,8 +54,9 @@ oss_impl <- function(df, var, distance = "euclidean", call = caller_env()) {
   counts <- table(outcome)
   minority <- names(counts)[which.min(counts)]
 
-  # Step 1: CNN condensing removes redundant majority class observations.
-  cnn_removed <- cnn_impl(df, var, distance = distance, call = call)
+  # Step 1: a single condensation pass removes redundant majority class
+  # observations, following Kubat & Matwin (1997).
+  cnn_removed <- oss_condense(df, var, distance = distance)
 
   keep <- setdiff(seq_len(nrow(df)), cnn_removed)
   kept_df <- df[keep, , drop = FALSE]
@@ -66,4 +67,45 @@ oss_impl <- function(df, var, distance = "euclidean", call = caller_env()) {
   tomek_removed <- tomek_removed[outcome[tomek_removed] != minority]
 
   sort(unique(c(cnn_removed, tomek_removed)))
+}
+
+# One-sided selection uses a single condensation pass rather than iterating to
+# consistency like Hart's CNN (Kubat & Matwin, 1997).
+oss_condense <- function(df, var, distance = "euclidean") {
+  outcome <- as.character(df[[var]])
+  predictors <- as.matrix(df[names(df) != var])
+
+  counts <- table(outcome)
+  minority <- names(counts)[which.min(counts)]
+
+  minority_idx <- which(outcome == minority)
+  majority_idx <- which(outcome != minority)
+
+  if (length(majority_idx) == 0) {
+    return(integer(0))
+  }
+
+  # Seed the store with all minority observations and one random majority one.
+  in_store <- logical(nrow(df))
+  in_store[minority_idx] <- TRUE
+  in_store[majority_idx[sample.int(length(majority_idx), 1)]] <- TRUE
+
+  # Single pass: scan order is randomized; condensation is order-dependent.
+  candidates <- sample(majority_idx[!in_store[majority_idx]])
+
+  for (i in candidates) {
+    store_idx <- which(in_store)
+    nn <- nn_indices_cross(
+      predictors[i, , drop = FALSE],
+      predictors[store_idx, , drop = FALSE],
+      k = 1,
+      distance = distance
+    )
+    if (outcome[store_idx[nn[1, 1]]] != outcome[i]) {
+      in_store[i] <- TRUE
+    }
+  }
+
+  # Majority observations left outside the store are removed.
+  which(!in_store)
 }

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -285,9 +285,9 @@ smogn_generate <- function(
     } else {
       # Unsafe: perturb the seed with Gaussian noise
       new_x[i, ] <- x[s, ] +
-        stats::rnorm(ncol(x), 0, perturbation * pmin(sd_x, maxD))
+        stats::rnorm(ncol(x), 0, sd_x * min(perturbation, maxD))
       new_y[i] <- y[s] +
-        stats::rnorm(1, 0, perturbation * min(sd_y, maxD))
+        stats::rnorm(1, 0, sd_y * min(perturbation, maxD))
     }
   }
 

--- a/tests/testthat/test-ncl.R
+++ b/tests/testthat/test-ncl.R
@@ -41,6 +41,27 @@ test_that("neighbors argument changes result", {
   expect_false(identical(nrow(baked1), nrow(baked5)))
 })
 
+test_that("class exactly at the cleaning threshold is eligible (>=)", {
+  # A minority "A" point is surrounded by "B" points, so B pollutes its
+  # neighborhood. With counts A = B = 3 and threshold_clean = 1, class B sits
+  # exactly at the boundary: Laurikkala's >= cleans it, the old > did not.
+  df <- data.frame(
+    x = c(0, 10, 11, 0.1, 0.2, 0.3),
+    y = 0,
+    class = factor(c("A", "A", "A", "B", "B", "B"))
+  )
+
+  removed <- themis:::ncl_impl(
+    df,
+    var = "class",
+    neighbors = 3,
+    threshold_clean = 1
+  )
+
+  expect_setequal(as.character(df$class[removed]), "B")
+  expect_gt(length(removed), 0)
+})
+
 test_that("threshold_clean argument changes result", {
   circle_numeric <- circle_example[, c("x", "y", "class")]
 

--- a/tests/testthat/test-oss.R
+++ b/tests/testthat/test-oss.R
@@ -39,6 +39,25 @@ test_that("removes the union of CNN and majority Tomek links", {
   expect_all_true(as.character(df$class[removed]) != minority)
 })
 
+test_that("condensation is a single pass, not iterated to convergence", {
+  df <- circle_example[, c("x", "y", "class")]
+
+  oss_rm <- withr::with_seed(1, themis:::oss_condense(df, var = "class"))
+  cnn_rm <- withr::with_seed(1, themis:::cnn_impl(df, var = "class"))
+
+  # A single pass keeps a store no larger than the converged CNN, so it removes
+  # a superset of the CNN store.
+  expect_all_true(cnn_rm %in% oss_rm)
+  expect_gte(length(oss_rm), length(cnn_rm))
+
+  # OSS condenses with a single pass and no longer defers to the fully
+  # converged CNN of cnn_impl().
+  local_mocked_bindings(
+    cnn_impl = function(...) cli::cli_abort("cnn_impl should not be called")
+  )
+  expect_no_error(withr::with_seed(1, themis:::oss_impl(df, var = "class")))
+})
+
 test_that("seed makes step reproducible", {
   baked <- function() {
     recipe(class ~ x + y, data = circle_example) |>

--- a/tests/testthat/test-smogn_impl.R
+++ b/tests/testthat/test-smogn_impl.R
@@ -118,6 +118,28 @@ test_that("single-element bins keep their own observation (#245)", {
   }
 })
 
+test_that("unsafe noise is scaled by sd and capped at maxD, not perturbation", {
+  set.seed(1)
+  # Equidistant points force every draw to be unsafe (d = sqrt(2) > maxD),
+  # so the Gaussian noise sd is sd_x * min(perturbation, maxD).
+  x <- diag(6)
+  y <- seq_len(6)
+
+  res <- themis:::smogn_generate(
+    x,
+    y,
+    n_generate = 2000,
+    k = 3,
+    perturbation = 1e6,
+    distance = "euclidean"
+  )
+
+  # With the reference formula the noise stays bounded by sd_x * maxD; the old
+  # formula (perturbation * pmin(sd_x, maxD)) would blow up with perturbation.
+  # Seeds are 0/1 vectors, so bounded noise keeps every value near [0, 1].
+  expect_lt(max(abs(res$x)), 5)
+})
+
 test_that("bad args", {
   circle_numeric <- circle_example[, c("x", "y")]
 


### PR DESCRIPTION
This addresses the three deviations from the source papers described in #250.

## SMOGN noise scale (`R/smogn_impl.R`)
For unsafe cases the Gaussian perturbation was scaled as `perturbation * pmin(sd_x, maxD)`, mixing a feature standard deviation with a distance quantity of mismatched units. The reference scales the noise by each feature's standard deviation and caps the perturbation amount at the safe distance: `sd * min(perturbation, maxD)`. Both the predictor and outcome noise now use this form.

## OSS single condensation pass (`R/oss_impl.R`)
OSS previously called `cnn_impl()`, which iterates Condensed Nearest Neighbors to convergence, removing more majority observations than Kubat & Matwin (1997), who use a single condensation pass. OSS now uses a dedicated single-pass `oss_condense()` helper. Hart's `cnn()`/`step_cnn()` keep their converging behavior.

## NCL cleaning-threshold tie (`R/ncl_impl.R`)
The eligibility check used a strict `>`, excluding a majority class whose size is exactly `threshold_clean` times the minority size. Laurikkala (2001) uses `>=`; the comparison is now `>=`.

Each fix has an accompanying test, and `NEWS.md` gains one bullet per affected step. Full test suite passes.

Closes #250