### PR TITLE
Exclude self by row index in neighbor searches (#247)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `step_smote()`, `step_adasyn()`, `step_bsmote()`, `step_svmsmote()`, `step_smoten()`, and `step_smotenc()` (and their direct-implementation counterparts) now round the fractional oversampling target instead of truncating it, so a fractional `over_ratio` lands on the nearest integer count (#248).
 
+* Nearest-neighbor computations in `step_adasyn()`, `step_enn()`, `step_ncl()`, `step_smote()`, `step_smotenc()`, and `step_tomek()` (and their direct-implementation counterparts) now exclude each observation from its own neighbor list by row index rather than assuming it is always the first neighbor returned. Exact-duplicate coordinates could previously leave a point as its own neighbor or make the farthest candidate unreachable (#247).
+
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) now weights minority observations by their exact majority-neighbor count. An off-by-one subtraction previously undercounted majority neighbors, zeroing out the weight of border points with a single majority neighbor and biasing sampling away from the class boundary (#239).
 
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) no longer errors with a cryptic message when a minority class is well separated from the majority classes; it now falls back to uniform sampling and checks the minority class size before sampling (#240).

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -126,7 +126,7 @@ adasyn_sampler <- function(
   smote_ids,
   distance = "euclidean"
 ) {
-  ids <- nn_indices(data, k, distance)
+  ids <- drop_self_neighbor(nn_indices(data, k, distance))
   index_len <- tabulate(smote_ids, NROW(data))
   out <- matrix(0, nrow = n_samples, ncol = ncol(data))
   sampleids <- sample.int(k, n_samples, TRUE)
@@ -135,8 +135,8 @@ adasyn_sampler <- function(
   iii <- 0
   for (row_num in which(index_len != 0)) {
     index_selection <- iii + seq_len(index_len[row_num])
-    # removes itself as nearest neighbour
-    id_knn <- ids[row_num, ids[row_num, ] != row_num]
+    # self already removed by drop_self_neighbor()
+    id_knn <- ids[row_num, ]
     dif <- data[id_knn[sampleids[index_selection]], ] -
       data[rep(row_num, index_len[row_num]), ]
     gap <- dif * runif_ids[index_selection]

--- a/R/enn_impl.R
+++ b/R/enn_impl.R
@@ -138,8 +138,9 @@ enn_single <- function(df, var, neighbors, distance) {
   outcome <- df[[var]]
 
   idx <- nn_indices(as.matrix(df[names(df) != var]), k = neighbors, distance)
-  # First column is the observation itself; drop it
-  idx <- idx[, -1, drop = FALSE]
+  # Drop each observation from its own neighbor list (by row index, so exact
+  # duplicates are handled correctly)
+  idx <- drop_self_neighbor(idx)
 
   neighbor_classes <- matrix(
     outcome[idx],

--- a/R/misc.R
+++ b/R/misc.R
@@ -200,6 +200,26 @@ check_distance_arg <- function(distance, call = caller_env()) {
   )
 }
 
+# Drop the query point from each row of a neighbor-index matrix. `idx` has one
+# row per query point and `k + 1` columns (the self-match plus `k` neighbors).
+# The self-match is normally in the first column, but with exact-duplicate
+# coordinates it can appear in any column or be missing entirely. Remove the
+# column whose index equals the query row; if self is not present, drop the
+# farthest (last) neighbor instead. Returns a matrix with `k` columns.
+drop_self_neighbor <- function(idx) {
+  n <- nrow(idx)
+  out <- matrix(0L, nrow = n, ncol = ncol(idx) - 1L)
+  for (i in seq_len(n)) {
+    row <- idx[i, ]
+    pos <- which(row == i)[1]
+    if (is.na(pos)) {
+      pos <- length(row)
+    }
+    out[i, ] <- row[-pos]
+  }
+  out
+}
+
 nn_indices <- function(data, k, distance) {
   if (distance == "euclidean") {
     return(RANN::nn2(data, k = k + 1, searchtype = "priority")$nn.idx)

--- a/R/ncl_impl.R
+++ b/R/ncl_impl.R
@@ -93,8 +93,9 @@ ncl_impl <- function(
   )
 
   idx <- nn_indices(as.matrix(df[names(df) != var]), k = neighbors, distance)
-  # First column is the observation itself; drop it
-  idx <- idx[, -1, drop = FALSE]
+  # Drop each observation from its own neighbor list (by row index, so exact
+  # duplicates are handled correctly)
+  idx <- drop_self_neighbor(idx)
 
   neighbor_classes <- matrix(
     outcome[idx],

--- a/R/smote_impl.R
+++ b/R/smote_impl.R
@@ -113,7 +113,7 @@ smote_data <- function(
   step_size = 1,
   majority_neighbors = NULL
 ) {
-  ids <- nn_indices(data, k, distance)
+  ids <- drop_self_neighbor(nn_indices(data, k, distance))
   indexes <- rep(sample(smote_ids), length.out = n_samples)
   index_len <- tabulate(indexes, NROW(data))
   out <- matrix(0, nrow = n_samples, ncol = ncol(data))
@@ -123,8 +123,8 @@ smote_data <- function(
   iii <- 0
   for (row_num in smote_ids) {
     index_selection <- iii + seq_len(index_len[row_num])
-    # removes itself as nearest neighbour
-    id_knn <- ids[row_num, ids[row_num, ] != row_num]
+    # self already removed by drop_self_neighbor()
+    id_knn <- ids[row_num, ]
     selected <- id_knn[sampleids[index_selection]]
     dif <- data[selected, ] - data[rep(row_num, index_len[row_num]), ]
     step <- rep(step_size, length(index_selection))

--- a/R/smotenc_impl.R
+++ b/R/smotenc_impl.R
@@ -131,6 +131,9 @@ smotenc_data <- function(
       }
     }
   )
+  # Drop each observation from its own neighbor list (by row index, so exact
+  # duplicates are handled correctly)
+  ids <- drop_self_neighbor(ids)
 
   # shuffles minority indicies and repeats that shuffling until the desired number of samples is reached
   indexes <- rep(sample(smotenc_ids), length.out = n_samples)
@@ -156,8 +159,8 @@ smotenc_data <- function(
     # List indices from 1:n where n is the number of times that sample is used to generate a new sample
     # iii shifts 1:n to fill in the rows of out (e.g. 1:3, 4:6, 7:8, etc.)
     index_selection <- iii + seq_len(index_len[row_num])
-    # removes itself as nearest neighbour
-    id_knn <- ids[row_num, ids[row_num, ] != row_num]
+    # self already removed by drop_self_neighbor()
+    id_knn <- ids[row_num, ]
 
     # need a total of index_len[row_num] new samples
     # calculates Xnew = X1 + t*(X1-Xnn)

--- a/R/tomek_impl.R
+++ b/R/tomek_impl.R
@@ -43,8 +43,9 @@ tomek <- function(df, var, distance = "euclidean") {
 
 tomek_impl <- function(df, var, distance = "euclidean") {
   res <- nn_indices(as.matrix(df[names(df) != var]), k = 1, distance)
-  # Make sure itself isn't counted as nearest neighbor for overlaps
-  res <- dplyr::if_else(seq_len(nrow(res)) == res[, 2], res[, 1], res[, 2])
+  # Drop each observation from its own neighbor list (by row index, so exact
+  # duplicates are handled correctly) and keep the single nearest neighbor
+  res <- drop_self_neighbor(res)[, 1]
 
   remove <- logical(nrow(df))
   outcome <- df[[var]]

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -389,6 +389,18 @@ test_that("enn() works with a character `var` (#261)", {
   expect_identical(sum(is.na(res$class)), 0L)
 })
 
+test_that("enn() handles exact-duplicate coordinates (#247)", {
+  df <- data.frame(
+    x = c(rep(0, 6), 1, 2, 3, 4),
+    y = c(rep(0, 6), 1, 2, 3, 4),
+    class = factor(c(rep("a", 3), rep("b", 3), "a", "b", "a", "b"))
+  )
+
+  # Duplicated points at (0, 0) belong to both classes; a point must not be
+  # kept purely because it counted itself as a neighbor.
+  expect_no_error(enn(df, var = "class", neighbors = 3))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -70,3 +70,20 @@ test_that("mahalanobis whitening reproduces stats::mahalanobis distances (#237)"
 
   expect_equal(themis_d2, unname(true_d2))
 })
+
+test_that("drop_self_neighbor() removes self by row index for duplicates (#247)", {
+  # Self in the first column (typical, non-duplicate case)
+  idx <- rbind(c(1L, 2L, 3L), c(2L, 1L, 3L), c(3L, 1L, 2L))
+  expect_identical(
+    drop_self_neighbor(idx),
+    rbind(c(2L, 3L), c(1L, 3L), c(1L, 2L))
+  )
+
+  # Self not in the first column (duplicate coordinates)
+  idx <- rbind(c(2L, 1L, 3L), c(1L, 2L, 3L))
+  expect_identical(drop_self_neighbor(idx), rbind(c(2L, 3L), c(1L, 3L)))
+
+  # Self missing entirely: drop the farthest (last) neighbor
+  idx <- rbind(c(2L, 3L, 4L), c(3L, 4L, 1L))
+  expect_identical(drop_self_neighbor(idx), rbind(c(2L, 3L), c(3L, 4L)))
+})

--- a/tests/testthat/test-smote_impl.R
+++ b/tests/testthat/test-smote_impl.R
@@ -37,6 +37,19 @@ test_that("distance argument accepted by smote()", {
   )
 })
 
+test_that("smote() handles exact-duplicate minority coordinates (#247)", {
+  df <- data.frame(
+    x = c(0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8),
+    y = c(0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8),
+    class = factor(rep(c("min", "maj"), each = 8))
+  )
+
+  res <- smote(df, var = "class", k = 3)
+
+  expect_identical(as.integer(table(res$class)), c(8L, 8L))
+  expect_identical(sum(is.na(res)), 0L)
+})
+
 
 test_that("distance variants produce valid synthetic data", {
   circle_numeric <- circle_example[, c("x", "y", "class")]


### PR DESCRIPTION
## Summary

Several nearest-neighbor implementations assumed the query point was always neighbor #1 (or always present among the returned `k + 1` neighbors). With exact-duplicate coordinates that assumption can break, so a point could be retained as its own neighbor, or the farthest candidate could become unreachable.

This adds a shared `drop_self_neighbor()` helper that removes each observation from its own neighbor list by matching the row index, falling back to dropping the farthest neighbor when self is absent. It is applied in `enn_impl.R`, `ncl_impl.R`, `tomek_impl.R`, `smote_impl.R`, `adasyn_impl.R`, and `smotenc_impl.R`. Behavior is unchanged in the non-duplicate case.

## Tests

- Direct unit test of `drop_self_neighbor()` covering self-in-first-column, self-not-first, and self-absent cases.
- Integration tests for `smote()` and `enn()` with exact-duplicate coordinates.

Closes #247