### PR TITLE
Fix sample() length-1 footguns in cnn/smogn

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
 
+* `step_cnn()`, `step_oss()`, and `step_smogn()` (and their direct-implementation counterparts `cnn()`, `oss()`, and `smogn()`) now sample correctly when only one candidate remains. A length-1 vector passed to `sample()` was interpreted as a count and sampled from `1:n`, which could select the wrong observations (#245).
+
 * `step_enn()` (and its direct-implementation counterpart `enn()`) was added. It cleans the data using the Edited Nearest Neighbors rule, removing observations whose class differs from the majority of their nearest neighbors (#115).
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) gain a `times` argument to apply the cleaning repeatedly, stopping early on convergence, which corresponds to Repeated Edited Nearest Neighbors (RENN) (#173).

--- a/R/cnn_impl.R
+++ b/R/cnn_impl.R
@@ -68,7 +68,8 @@ cnn_impl <- function(df, var, distance = "euclidean", call = caller_env()) {
   repeat {
     added <- FALSE
     # Scan order is randomized; CNN is order-dependent.
-    candidates <- sample(majority_idx[!in_store[majority_idx]])
+    remaining <- majority_idx[!in_store[majority_idx]]
+    candidates <- remaining[sample.int(length(remaining))]
 
     for (i in candidates) {
       store_idx <- which(in_store)

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -122,7 +122,7 @@ smogn_impl <- function(
     bin_df <- df[idx, , drop = FALSE]
 
     if (n_i >= target) {
-      keep_dfs[[b]] <- df[sample(idx, target), , drop = FALSE]
+      keep_dfs[[b]] <- df[idx[sample.int(length(idx), target)], , drop = FALSE]
       next
     }
 

--- a/tests/testthat/test-oss.R
+++ b/tests/testthat/test-oss.R
@@ -301,6 +301,25 @@ test_that("oss() works with a character `var` (#261)", {
   expect_identical(sum(is.na(res$class)), 0L)
 })
 
+test_that("cnn scan handles a single remaining majority candidate (#245)", {
+  # Two majority points seed the store with one, leaving a length-1 candidate
+  # vector that must not be treated as a `sample()` count.
+  df <- data.frame(
+    x = c(rnorm(10, 0), 5, 5.1),
+    y = c(rnorm(10, 0), 5, 4.9),
+    class = c(rep("a", 10), "b", "b")
+  )
+
+  set.seed(42)
+  res1 <- oss(df, "class")
+  set.seed(42)
+  res2 <- oss(df, "class")
+
+  expect_identical(res1, res2)
+  expect_identical(sort(unique(res1$class)), c("a", "b"))
+  expect_all_true(do.call(paste, res1) %in% do.call(paste, df))
+})
+
 # Infrastructure ---------------------------------------------------------------
 
 test_that("bake method errors when needed non-standard role columns are missing", {

--- a/tests/testthat/test-smogn_impl.R
+++ b/tests/testthat/test-smogn_impl.R
@@ -96,6 +96,19 @@ test_that("smogn() interfaces correctly", {
   )
 })
 
+test_that("single-element bins keep their own observation (#245)", {
+  # Each value forms its own bin with target 1, so the keep branch subsets a
+  # length-1 index that must not be treated as a `sample()` count.
+  df <- data.frame(x = c(1, 2), y = c(0, 100))
+  rel <- matrix(c(0, 50, 100, 0, 0, 1), ncol = 2)
+
+  for (seed in 1:20) {
+    set.seed(seed)
+    res <- smogn(df, var = "y", relevance = rel, perturbation = 0)
+    expect_equal(sort(res$y), c(0, 100))
+  }
+})
+
 test_that("bad args", {
   circle_numeric <- circle_example[, c("x", "y")]
 


### PR DESCRIPTION
`sample(x)` with a length-1 integer `x` samples from `1:x` instead of returning `x`. Two spots relied on `sample()` over vectors that can shrink to length 1:

- `R/cnn_impl.R`: the candidate scan (`sample(majority_idx[...])`, reachable via `oss()` and `cnn()`) now uses `remaining[sample.int(length(remaining))]`.
- `R/smogn_impl.R`: the keep branch (`sample(idx, target)`) now uses `idx[sample.int(length(idx), target)]`, preserving the original size (no replacement) semantics.

Added tests exercising the length-1 path for cnn (via `oss()`) and smogn, plus a NEWS bullet.

Closes #245