### PR TITLE
Add indicator_column argument to step_smoten() (#253)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
 
 * `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
 
+* `step_smoten()` now gains an `indicator_column` argument for parity with the other over-sampling steps. When set, a logical column is added to the baked data marking synthetic rows (#253).
+
 * `step_smotenc()` (and its direct-implementation counterpart `smotenc()`) now sets each synthetic sample's nominal features to the majority vote across the seed's k nearest neighbors, matching the SMOTENC algorithm, rather than voting over the randomly chosen interpolation partners (#241).
 
 * `step_tomek()` (and its direct-implementation counterpart `tomek()`) now removes only the majority-class member of each Tomek link, retaining the minority-class member, matching the documented behavior. Previously it removed both members of the pair (#262).

--- a/R/smoten.R
+++ b/R/smoten.R
@@ -101,11 +101,13 @@ step_smoten <-
     column = NULL,
     over_ratio = 1,
     neighbors = 5,
+    indicator_column = NULL,
     skip = TRUE,
     seed = sample.int(10^5, 1),
     id = rand_id("smoten")
   ) {
     check_number_whole(seed)
+    check_string(indicator_column, allow_null = TRUE, allow_empty = FALSE)
 
     add_step(
       recipe,
@@ -117,6 +119,7 @@ step_smoten <-
         over_ratio = over_ratio,
         neighbors = neighbors,
         predictors = NULL,
+        indicator_column = indicator_column,
         skip = skip,
         seed = seed,
         id = id
@@ -133,6 +136,7 @@ step_smoten_new <-
     over_ratio,
     neighbors,
     predictors,
+    indicator_column,
     skip,
     seed,
     id
@@ -146,6 +150,7 @@ step_smoten_new <-
       over_ratio = over_ratio,
       neighbors = neighbors,
       predictors = predictors,
+      indicator_column = indicator_column,
       skip = skip,
       seed = seed,
       id = id
@@ -163,6 +168,13 @@ prep.step_smoten <- function(x, training, info = NULL, ...) {
   check_column_factor(training, col_name)
   warn_unused_levels(training, col_name)
 
+  recipes::check_name(
+    tibble(x = logical(0)),
+    training,
+    x,
+    newname = x$indicator_column
+  )
+
   predictors <- setdiff(recipes::recipes_names_predictors(info), col_name)
   check_na(select(training, all_of(c(col_name, predictors))))
   check_all_categorical(select(training, all_of(predictors)))
@@ -175,6 +187,7 @@ prep.step_smoten <- function(x, training, info = NULL, ...) {
     over_ratio = x$over_ratio,
     neighbors = x$neighbors,
     predictors = predictors,
+    indicator_column = x$indicator_column,
     skip = x$skip,
     seed = x$seed,
     id = x$id
@@ -194,6 +207,7 @@ bake.step_smoten <- function(object, new_data, ...) {
     return(new_data)
   }
 
+  n_orig <- nrow(new_data)
   new_data <- as.data.frame(new_data)
 
   predictor_data <- new_data[, col_names]
@@ -212,6 +226,8 @@ bake.step_smoten <- function(object, new_data, ...) {
     }
   )
   new_data <- na_splice(new_data, synthetic_data, object)
+
+  new_data <- add_indicator_column(new_data, n_orig, object$indicator_column)
 
   new_data
 }

--- a/man/step_smoten.Rd
+++ b/man/step_smoten.Rd
@@ -13,6 +13,7 @@ step_smoten(
   column = NULL,
   over_ratio = 1,
   neighbors = 5,
+  indicator_column = NULL,
   skip = TRUE,
   seed = sample.int(10^5, 1),
   id = rand_id("smoten")
@@ -46,6 +47,11 @@ half as many rows as the majority level. See
 
 \item{neighbors}{An integer. Number of nearest neighbor that are used
 to generate the new examples of the minority class.}
+
+\item{indicator_column}{A single string or \code{NULL} (the default). If a
+string is given, a logical column with that name is added to the output,
+marking rows added by the step (\code{TRUE}) vs rows from the original data
+(\code{FALSE}).}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/tests/testthat/_snaps/smoten.md
+++ b/tests/testthat/_snaps/smoten.md
@@ -35,6 +35,34 @@
       Caused by error in `prep()`:
       ! Cannot have any missing values. NAs found in x.
 
+# indicator_column bad args
+
+    Code
+      step_smoten(recipe(class ~ x + y, data = cat_example), class, indicator_column = 1)
+    Condition
+      Error in `step_smoten()`:
+      ! `indicator_column` must be a single string or `NULL`, not the number 1.
+
+---
+
+    Code
+      prep(step_smoten(recipe(class ~ x + y, data = cat_example), class,
+      indicator_column = ""))
+    Condition
+      Error in `step_smoten()`:
+      ! `indicator_column` must be a single string or `NULL`, not the empty string "".
+
+---
+
+    Code
+      prep(step_smoten(recipe(class ~ x + y, data = cat_example), class,
+      indicator_column = "x"))
+    Condition
+      Error in `step_smoten()`:
+      Caused by error in `prep()`:
+      ! Name collision occurred. The following variable names already exist:
+      * `x`
+
 # bad args
 
     Code

--- a/tests/testthat/test-smoten.R
+++ b/tests/testthat/test-smoten.R
@@ -230,6 +230,39 @@ test_that("tunable", {
   )
 })
 
+test_that("indicator_column adds logical column marking synthetic rows", {
+  rec <- recipe(class ~ x + y, data = cat_example) |>
+    step_smoten(class, indicator_column = ".new_row") |>
+    prep()
+
+  res <- bake(rec, new_data = NULL)
+
+  expect_true(".new_row" %in% names(res))
+  expect_type(res$.new_row, "logical")
+  expect_equal(sum(!res$.new_row), nrow(cat_example))
+  expect_gt(sum(res$.new_row), 0L)
+})
+
+test_that("indicator_column bad args", {
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ x + y, data = cat_example) |>
+      step_smoten(class, indicator_column = 1)
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ x + y, data = cat_example) |>
+      step_smoten(class, indicator_column = "") |>
+      prep()
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ x + y, data = cat_example) |>
+      step_smoten(class, indicator_column = "x") |>
+      prep()
+  )
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
Closes #253

`step_smoten()` was the only over-sampling step that did not expose an `indicator_column` argument, and its `bake` never called `add_indicator_column`, contradicting the NEWS claim that all upsampling steps gained `indicator_column`.

This threads `indicator_column` through the constructor, `step_smoten_new()`, `prep` (including the `check_name` collision check), and `bake` (calling `add_indicator_column`), matching the pattern used in `step_smote()`. Docs are inherited via `@inheritParams step_upsample`. Adds tests mirroring the `step_smote()` indicator_column tests and a NEWS bullet.