### PR TITLE
Avoid O(n^2) neighbor recomputes in ADASYN, CNN, and OSS (#257)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) no longer errors with a cryptic message when a minority class is well separated from the majority classes; it now falls back to uniform sampling and checks the minority class size before sampling (#240).
 
+* `step_adasyn()`, `step_cnn()`, and `step_oss()` (and their direct-implementation counterparts `adasyn()`, `cnn()`, and `oss()`) are now faster on large data. `step_adasyn()` computes the full-data nearest neighbors only for the minority observations it needs, and `step_cnn()`/`step_oss()` compute the condensation nearest neighbors for all candidates in one batch per store change instead of once per candidate. Results are unchanged (#257).
+
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) now selects the correct "danger" observations on the class border. The danger criterion had inverted the roles of minority and majority neighbors, causing it to oversample safe interior points instead of borderline ones (#235).
 
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) with `all_neighbors = TRUE` now seeds synthetic points only from minority-class danger observations and takes a reduced step toward majority-class neighbors, matching borderline-SMOTE2. Previously it could seed from border-adjacent majority rows, generating minority-labeled points around majority centers (#242).

--- a/R/adasyn_impl.R
+++ b/R/adasyn_impl.R
@@ -68,7 +68,6 @@ adasyn_impl <- function(
   out_dfs <- list()
 
   data_mat <- as.matrix(df[names(df) != var])
-  ids_full <- nn_indices(data_mat, k, distance)
 
   for (i in seq_along(min_names)) {
     min_class_in <- df[[var]] != min_names[i]
@@ -85,8 +84,13 @@ adasyn_impl <- function(
       )
     }
 
-    r_value <- rowSums(matrix((min_class_in)[ids_full], ncol = ncol(ids_full)))
-    r_value <- r_value[!min_class_in]
+    # r_value counts the majority-class neighbors among each minority point's
+    # k + 1 nearest neighbors in the full data. Query only the minority rows
+    # against the full data instead of computing neighbors for every row and
+    # discarding the majority ones; the neighbor sets (and thus r_value) are
+    # identical.
+    ids <- nn_indices_cross(minority, data_mat, k + 1, distance)
+    r_value <- rowSums(matrix((min_class_in)[ids], ncol = ncol(ids)))
     # When the minority class is well separated from the majority classes all
     # weights are 0, which `sample()` cannot use. Fall back to uniform sampling.
     if (all(r_value == 0)) {

--- a/R/cnn_impl.R
+++ b/R/cnn_impl.R
@@ -66,26 +66,14 @@ cnn_impl <- function(df, var, distance = "euclidean", call = caller_env()) {
   in_store[majority_idx[sample.int(length(majority_idx), 1)]] <- TRUE
 
   repeat {
-    added <- FALSE
     # Scan order is randomized; CNN is order-dependent.
     remaining <- majority_idx[!in_store[majority_idx]]
     candidates <- remaining[sample.int(length(remaining))]
 
-    for (i in candidates) {
-      store_idx <- which(in_store)
-      nn <- nn_indices_cross(
-        predictors[i, , drop = FALSE],
-        predictors[store_idx, , drop = FALSE],
-        k = 1,
-        distance = distance
-      )
-      if (outcome[store_idx[nn[1, 1]]] != outcome[i]) {
-        in_store[i] <- TRUE
-        added <- TRUE
-      }
-    }
+    res <- condense_scan(candidates, in_store, predictors, outcome, distance)
+    in_store <- res$in_store
 
-    if (!added) {
+    if (!res$added) {
       break
     }
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -220,29 +220,55 @@ drop_self_neighbor <- function(idx) {
   out
 }
 
-nn_indices <- function(data, k, distance) {
-  if (distance == "euclidean") {
-    return(RANN::nn2(data, k = k + 1, searchtype = "priority")$nn.idx)
-  }
+# Metrics whose distance equals ordinary Euclidean distance after a per-row or
+# linear transform of the data, so the neighbor search can run on the transformed
+# coordinates. manhattan and chebyshev are not in this set and must be computed
+# with `stats::dist()` directly.
+metric_is_transformable <- function(distance) {
+  distance %in% c("euclidean", "cosine", "mahalanobis")
+}
+
+# Transform `data` so that Euclidean distance on the result equals the requested
+# metric. For mahalanobis the whitening transform is derived from `cov_data`
+# (the reference set in cross-distance calls) so a query and reference set can
+# share one transform. `check_singular` toggles the guard for a covariance that
+# cannot be inverted (more predictors than observations). Cosine-distance
+# consumers that need true magnitudes must still convert the resulting Euclidean
+# distance `d` via `d^2 / 2`; only the coordinate transform lives here.
+metric_transform <- function(
+  data,
+  distance,
+  cov_data = data,
+  check_singular = TRUE,
+  call = caller_env()
+) {
   if (distance == "cosine") {
     norms <- sqrt(rowSums(data^2))
     norms[norms == 0] <- 1
-    data_norm <- data / norms
-    return(RANN::nn2(data_norm, k = k + 1, searchtype = "priority")$nn.idx)
+    return(data / norms)
   }
   if (distance == "mahalanobis") {
-    if (nrow(data) <= ncol(data)) {
+    if (check_singular && nrow(cov_data) <= ncol(cov_data)) {
       cli::cli_abort(
         c(
           "{.code distance = \"mahalanobis\"} requires more observations than predictors in each class.",
-          i = "{nrow(data)} observation{?s} {?was/were} found but {ncol(data)} predictor{?s} {?is/are} present.",
+          i = "{nrow(cov_data)} observation{?s} {?was/were} found but {ncol(cov_data)} predictor{?s} {?is/are} present.",
           i = "Try a different {.arg distance} metric or reduce the number of predictors."
-        )
+        ),
+        call = call
       )
     }
-    S <- stats::cov(data)
-    data_w <- data %*% solve(chol(S))
-    return(RANN::nn2(data_w, k = k + 1, searchtype = "priority")$nn.idx)
+    S <- stats::cov(cov_data)
+    return(data %*% solve(chol(S)))
+  }
+  # euclidean: no transform needed
+  data
+}
+
+nn_indices <- function(data, k, distance) {
+  if (metric_is_transformable(distance)) {
+    data <- metric_transform(data, distance)
+    return(RANN::nn2(data, k = k + 1, searchtype = "priority")$nn.idx)
   }
   dist_method <- switch(
     distance,
@@ -254,35 +280,17 @@ nn_indices <- function(data, k, distance) {
 }
 
 nn_dists_cross <- function(query, reference, k, distance) {
-  if (distance == "euclidean") {
-    return(RANN::nn2(reference, query, k = k)$nn.dists)
-  }
-  if (distance == "cosine") {
-    norms_ref <- sqrt(rowSums(reference^2))
-    norms_ref[norms_ref == 0] <- 1
-    norms_qry <- sqrt(rowSums(query^2))
-    norms_qry[norms_qry == 0] <- 1
-    # RANN returns Euclidean distances between unit vectors, sqrt(2 - 2*cos).
-    # Convert to cosine distance (1 - cos_sim = d^2 / 2) so magnitudes are
-    # correct for consumers such as NearMiss that average per-neighbor values.
-    d <- RANN::nn2(reference / norms_ref, query / norms_qry, k = k)$nn.dists
-    return(d^2 / 2)
-  }
-  if (distance == "mahalanobis") {
-    if (nrow(reference) <= ncol(reference)) {
-      cli::cli_abort(
-        c(
-          "{.code distance = \"mahalanobis\"} requires more observations than predictors in each class.",
-          i = "{nrow(reference)} observation{?s} {?was/were} found but {ncol(reference)} predictor{?s} {?is/are} present.",
-          i = "Try a different {.arg distance} metric or reduce the number of predictors."
-        )
-      )
+  if (metric_is_transformable(distance)) {
+    query_t <- metric_transform(query, distance, cov_data = reference)
+    reference_t <- metric_transform(reference, distance, cov_data = reference)
+    d <- RANN::nn2(reference_t, query_t, k = k)$nn.dists
+    if (distance == "cosine") {
+      # RANN returns Euclidean distances between unit vectors, sqrt(2 - 2*cos).
+      # Convert to cosine distance (1 - cos_sim = d^2 / 2) so magnitudes are
+      # correct for consumers such as NearMiss that average per-neighbor values.
+      return(d^2 / 2)
     }
-    S <- stats::cov(reference)
-    L_inv <- solve(chol(S))
-    reference_w <- reference %*% L_inv
-    query_w <- query %*% L_inv
-    return(RANN::nn2(reference_w, query_w, k = k)$nn.dists)
+    return(d)
   }
   dist_method <- switch(
     distance,
@@ -297,31 +305,10 @@ nn_dists_cross <- function(query, reference, k, distance) {
 }
 
 nn_indices_cross <- function(query, reference, k, distance) {
-  if (distance == "euclidean") {
-    return(RANN::nn2(reference, query, k = k)$nn.idx)
-  }
-  if (distance == "cosine") {
-    norms_ref <- sqrt(rowSums(reference^2))
-    norms_ref[norms_ref == 0] <- 1
-    norms_qry <- sqrt(rowSums(query^2))
-    norms_qry[norms_qry == 0] <- 1
-    return(RANN::nn2(reference / norms_ref, query / norms_qry, k = k)$nn.idx)
-  }
-  if (distance == "mahalanobis") {
-    if (nrow(reference) <= ncol(reference)) {
-      cli::cli_abort(
-        c(
-          "{.code distance = \"mahalanobis\"} requires more observations than predictors in each class.",
-          i = "{nrow(reference)} observation{?s} {?was/were} found but {ncol(reference)} predictor{?s} {?is/are} present.",
-          i = "Try a different {.arg distance} metric or reduce the number of predictors."
-        )
-      )
-    }
-    S <- stats::cov(reference)
-    L_inv <- solve(chol(S))
-    reference_w <- reference %*% L_inv
-    query_w <- query %*% L_inv
-    return(RANN::nn2(reference_w, query_w, k = k)$nn.idx)
+  if (metric_is_transformable(distance)) {
+    query_t <- metric_transform(query, distance, cov_data = reference)
+    reference_t <- metric_transform(reference, distance, cov_data = reference)
+    return(RANN::nn2(reference_t, query_t, k = k)$nn.idx)
   }
   dist_method <- switch(
     distance,

--- a/R/misc.R
+++ b/R/misc.R
@@ -222,8 +222,12 @@ drop_self_neighbor <- function(idx) {
 
 # Metrics whose distance equals ordinary Euclidean distance after a per-row or
 # linear transform of the data, so the neighbor search can run on the transformed
-# coordinates. manhattan and chebyshev are not in this set and must be computed
-# with `stats::dist()` directly.
+# coordinates via RANN. manhattan and chebyshev are not in this set: RANN only
+# supports Euclidean distance and there is no distance-preserving transform for
+# them, so they fall back to a dense `stats::dist()` matrix. Replacing that with a
+# lighter k-NN search would require either a new dependency or a hand-rolled
+# routine whose tie-breaking could differ from `order()`/`sort()` and change
+# results, so the dense path is kept for these two metrics.
 metric_is_transformable <- function(distance) {
   distance %in% c("euclidean", "cosine", "mahalanobis")
 }
@@ -301,7 +305,8 @@ nn_dists_cross <- function(query, reference, k, distance) {
   d_full <- as.matrix(stats::dist(combined, method = dist_method))
   nq <- nrow(query)
   d_cross <- d_full[seq_len(nq), nq + seq_len(nrow(reference)), drop = FALSE]
-  t(apply(d_cross, 1, \(x) sort(x)[seq_len(k)]))
+  res <- apply(d_cross, 1, \(x) sort(x)[seq_len(k)])
+  matrix(res, nrow = nq, ncol = k, byrow = TRUE)
 }
 
 nn_indices_cross <- function(query, reference, k, distance) {
@@ -319,7 +324,47 @@ nn_indices_cross <- function(query, reference, k, distance) {
   d_full <- as.matrix(stats::dist(combined, method = dist_method))
   nq <- nrow(query)
   d_cross <- d_full[seq_len(nq), nq + seq_len(nrow(reference)), drop = FALSE]
-  t(apply(d_cross, 1, \(x) order(x)[seq_len(k)]))
+  res <- apply(d_cross, 1, \(x) order(x)[seq_len(k)])
+  matrix(res, nrow = nq, ncol = k, byrow = TRUE)
+}
+
+# Shared condensation scan for CNN and one-sided selection. Walks `candidates`
+# in order and, using a 1-nearest-neighbor rule against the current store, adds
+# any candidate whose nearest stored neighbor has a different class. The store is
+# unchanged between additions, so the cross-NN is computed in one batch for all
+# not-yet-processed candidates and only recomputed after the store actually
+# changes, rather than rebuilding the neighbor search for every single candidate.
+# Results are identical to the per-candidate scan. Returns the updated `in_store`
+# and whether anything was added.
+condense_scan <- function(candidates, in_store, predictors, outcome, distance) {
+  added <- FALSE
+  batch <- NULL
+  store_idx <- NULL
+  base <- 0L
+  dirty <- TRUE
+  n <- length(candidates)
+  for (idx in seq_len(n)) {
+    i <- candidates[idx]
+    if (dirty) {
+      store_idx <- which(in_store)
+      remaining <- candidates[idx:n]
+      batch <- nn_indices_cross(
+        predictors[remaining, , drop = FALSE],
+        predictors[store_idx, , drop = FALSE],
+        k = 1,
+        distance = distance
+      )
+      base <- idx - 1L
+      dirty <- FALSE
+    }
+    nn1 <- batch[idx - base, 1]
+    if (outcome[store_idx[nn1]] != outcome[i]) {
+      in_store[i] <- TRUE
+      added <- TRUE
+      dirty <- TRUE
+    }
+  }
+  list(in_store = in_store, added = added)
 }
 
 weighted_table <- function(x, wts = NULL) {

--- a/R/oss_impl.R
+++ b/R/oss_impl.R
@@ -93,18 +93,8 @@ oss_condense <- function(df, var, distance = "euclidean") {
   # Single pass: scan order is randomized; condensation is order-dependent.
   candidates <- sample(majority_idx[!in_store[majority_idx]])
 
-  for (i in candidates) {
-    store_idx <- which(in_store)
-    nn <- nn_indices_cross(
-      predictors[i, , drop = FALSE],
-      predictors[store_idx, , drop = FALSE],
-      k = 1,
-      distance = distance
-    )
-    if (outcome[store_idx[nn[1, 1]]] != outcome[i]) {
-      in_store[i] <- TRUE
-    }
-  }
+  res <- condense_scan(candidates, in_store, predictors, outcome, distance)
+  in_store <- res$in_store
 
   # Majority observations left outside the store are removed.
   which(!in_store)

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -223,23 +223,21 @@ smogn_relevance <- function(y, relevance = NULL, call = caller_env()) {
 # Distance matrix within a bin, honoring the chosen metric by transforming the
 # data (cosine, mahalanobis) or using the appropriate `stats::dist` method.
 smogn_distmat <- function(data, distance) {
-  if (distance == "cosine") {
-    norms <- sqrt(rowSums(data^2))
-    norms[norms == 0] <- 1
-    # Euclidean distance between unit vectors is sqrt(2 - 2*cos); convert to
-    # cosine distance (1 - cos_sim = d^2 / 2) so the interpolate-vs-noise test
-    # compares true cosine-distance magnitudes.
-    d <- as.matrix(stats::dist(data / norms))
-    return(d^2 / 2)
-  }
-  if (distance == "mahalanobis") {
-    S <- stats::cov(data)
-    data <- data %*% solve(chol(S))
-    return(as.matrix(stats::dist(data)))
+  if (metric_is_transformable(distance)) {
+    # `check_singular = FALSE` preserves the historical behavior of relying on
+    # `chol()` to error on a singular covariance rather than the friendly guard.
+    data <- metric_transform(data, distance, check_singular = FALSE)
+    d <- as.matrix(stats::dist(data))
+    if (distance == "cosine") {
+      # Euclidean distance between unit vectors is sqrt(2 - 2*cos); convert to
+      # cosine distance (1 - cos_sim = d^2 / 2) so the interpolate-vs-noise test
+      # compares true cosine-distance magnitudes.
+      return(d^2 / 2)
+    }
+    return(d)
   }
   method <- switch(
     distance,
-    "euclidean" = "euclidean",
     "manhattan" = "manhattan",
     "chebyshev" = "maximum"
   )


### PR DESCRIPTION
Closes #257