### PR TITLE
Fix tunable and argument-consistency gaps (#254)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) with `all_neighbors = TRUE` now seeds synthetic points only from minority-class danger observations and takes a reduced step toward majority-class neighbors, matching borderline-SMOTE2. Previously it could seed from border-adjacent majority rows, generating minority-labeled points around majority centers (#242).
 
+* `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
+
 * `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
 
 * `step_cnn()`, `step_oss()`, and `step_smogn()` (and their direct-implementation counterparts `cnn()`, `oss()`, and `smogn()`) now sample correctly when only one candidate remains. A length-1 vector passed to `sample()` was interpreted as a count and sampled from `1:n`, which could select the wrong observations (#245).
@@ -26,11 +28,15 @@
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) gain an `all_k` argument to apply the cleaning with an increasing number of neighbors, from 1 up to `neighbors`, which corresponds to All k-Nearest Neighbors (AllKNN) (#174).
 
+* `step_enn()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `all_k` as a tunable parameter (#254).
+
 * `step_instance_hardness()` (and its direct-implementation counterpart `instance_hardness()`) was added. It under-samples the majority classes by removing the observations that are hardest to classify, estimated using the k-Disagreeing Neighbors measure (#172).
 
 * `step_ncl()` (and its direct-implementation counterpart `ncl()`) was added. It cleans the data using the Neighborhood Cleaning Rule, removing majority class observations that are noisy or that pollute the neighborhood of minority class observations (#116).
 
 * `step_ncl()` (and its direct-implementation counterpart `ncl()`) now treats a majority class whose size is exactly `threshold_clean` times the minority size as eligible for cleaning, using the `>=` comparison from Laurikkala (2001) instead of a strict `>` (#250).
+
+* `step_ncl()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `threshold_clean` as a tunable parameter (#254).
 
 * `step_nearmiss()` (and its direct-implementation counterpart `nearmiss()`) now keeps the majority observations that are genuinely closest to the minority class, rather than selecting rows by their position in the data (#236).
 
@@ -46,9 +52,15 @@
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) now scales the Gaussian perturbation of unsafe cases by each feature's standard deviation and caps the perturbation amount at the safe distance, using `sd * min(perturbation, maxD)` as in the reference, instead of scaling by a distance-capped standard deviation (#250).
 
+* `step_smogn()` now exposes `threshold` as a tunable parameter (#254).
+
 * `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
 
 * `step_smotenc()` (and its direct-implementation counterpart `smotenc()`) now sets each synthetic sample's nominal features to the majority vote across the seed's k nearest neighbors, matching the SMOTENC algorithm, rather than voting over the randomly chosen interpolation partners (#241).
+
+* `step_smotenc()` now validates that all predictors are numeric or nominal, erroring on unsupported column types such as dates instead of failing later (#254).
+
+* `step_svmsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
 
 * `step_tomek()` (and its direct-implementation counterpart `tomek()`) now removes only the majority-class member of each Tomek link, retaining the minority-class member, matching the documented behavior. Previously it removed both members of the pair (#262).
 

--- a/R/bsmote.R
+++ b/R/bsmote.R
@@ -310,7 +310,7 @@ tunable.step_bsmote <- function(x, ...) {
     name = c("over_ratio", "neighbors", "all_neighbors"),
     call_info = list(
       list(pkg = "dials", fun = "over_ratio"),
-      list(pkg = "dials", fun = "neighbors"),
+      list(pkg = "dials", fun = "neighbors", range = c(1, 10)),
       list(pkg = "dials", fun = "all_neighbors")
     ),
     source = "recipe",

--- a/R/enn.R
+++ b/R/enn.R
@@ -16,7 +16,8 @@
 #' @param column A character string of the variable name that will
 #'  be populated (eventually) by the `...` selectors.
 #' @param neighbors An integer. Number of nearest neighbor that are used to
-#'  decide whether an observation is removed.
+#'  decide whether an observation is removed. Defaults to `3`, unlike the
+#'  over-sampling steps which default to `5`.
 #' @param times A positive integer for the maximum number of times ENN is
 #'  applied. Defaults to `1` for a single pass. Values greater than `1` repeat
 #'  the cleaning, stopping early once a pass removes no observations. Use
@@ -139,7 +140,6 @@ step_enn <-
   ) {
     check_number_whole(seed)
     check_distance_arg(distance)
-    check_bool(all_k)
 
     add_step(
       recipe,
@@ -201,6 +201,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
 
   check_number_whole(x$neighbors, arg = "neighbors", min = 1)
   check_number_whole(x$times, arg = "times", min = 1, allow_infinite = TRUE)
+  check_bool(x$all_k, arg = "all_k")
   warn_times_all_k(x$times, x$all_k)
 
   check_1_selected(col_name)
@@ -300,9 +301,10 @@ tidy.step_enn <- function(x, ...) {
 #' @rdname tunable_themis
 tunable.step_enn <- function(x, ...) {
   tibble::tibble(
-    name = c("neighbors"),
+    name = c("neighbors", "all_k"),
     call_info = list(
-      list(pkg = "dials", fun = "neighbors", range = c(1, 10))
+      list(pkg = "dials", fun = "neighbors", range = c(1, 10)),
+      list(pkg = "dials", fun = "prune")
     ),
     source = "recipe",
     component = "step_enn",

--- a/R/ncl.R
+++ b/R/ncl.R
@@ -16,7 +16,8 @@
 #' @param column A character string of the variable name that will
 #'  be populated (eventually) by the `...` selectors.
 #' @param neighbors An integer. Number of nearest neighbor that are used to
-#'  decide whether an observation is removed.
+#'  decide whether an observation is removed. Defaults to `3`, unlike the
+#'  over-sampling steps which default to `5`.
 #' @param threshold_clean A numeric. Majority classes are only cleaned around
 #'  minority class observations when their size is greater than
 #'  `threshold_clean` times the size of the minority class. Defaults to `0.5`.
@@ -289,9 +290,10 @@ tidy.step_ncl <- function(x, ...) {
 #' @rdname tunable_themis
 tunable.step_ncl <- function(x, ...) {
   tibble::tibble(
-    name = c("neighbors"),
+    name = c("neighbors", "threshold_clean"),
     call_info = list(
-      list(pkg = "dials", fun = "neighbors", range = c(1, 10))
+      list(pkg = "dials", fun = "neighbors", range = c(1, 10)),
+      list(pkg = "dials", fun = "threshold")
     ),
     source = "recipe",
     component = "step_ncl",

--- a/R/smogn.R
+++ b/R/smogn.R
@@ -278,9 +278,10 @@ tidy.step_smogn <- function(x, ...) {
 #' @rdname tunable_themis
 tunable.step_smogn <- function(x, ...) {
   tibble::tibble(
-    name = c("neighbors"),
+    name = c("neighbors", "threshold"),
     call_info = list(
-      list(pkg = "dials", fun = "neighbors", range = c(1, 10))
+      list(pkg = "dials", fun = "neighbors", range = c(1, 10)),
+      list(pkg = "dials", fun = "threshold")
     ),
     source = "recipe",
     component = "step_smogn",

--- a/R/smotenc.R
+++ b/R/smotenc.R
@@ -184,6 +184,11 @@ prep.step_smotenc <- function(x, training, info = NULL, ...) {
   )
 
   predictors <- setdiff(recipes::recipes_names_predictors(info), col_name)
+
+  check_type(
+    training[, predictors],
+    types = c("double", "integer", "nominal")
+  )
   check_na(select(training, all_of(c(col_name, predictors))))
 
   step_smotenc_new(

--- a/R/svmsmote.R
+++ b/R/svmsmote.R
@@ -286,7 +286,7 @@ tunable.step_svmsmote <- function(x, ...) {
     name = c("over_ratio", "neighbors"),
     call_info = list(
       list(pkg = "dials", fun = "over_ratio"),
-      list(pkg = "dials", fun = "neighbors")
+      list(pkg = "dials", fun = "neighbors", range = c(1, 10))
     ),
     source = "recipe",
     component = "step_svmsmote",

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -188,8 +188,8 @@ step_upsample_new <-
       target = target,
       indicator_column = indicator_column,
       skip = skip,
-      id = id,
       seed = seed,
+      id = id,
       case_weights = case_weights
     )
   }

--- a/man/enn.Rd
+++ b/man/enn.Rd
@@ -13,7 +13,8 @@ numeric variables.}
 \item{var}{Character, name of variable containing factor variable.}
 
 \item{neighbors}{An integer. Number of nearest neighbor that are used to
-decide whether an observation is removed.}
+decide whether an observation is removed. Defaults to \code{3}, unlike the
+over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},

--- a/man/ncl.Rd
+++ b/man/ncl.Rd
@@ -13,7 +13,8 @@ numeric variables.}
 \item{var}{Character, name of variable containing factor variable.}
 
 \item{neighbors}{An integer. Number of nearest neighbor that are used to
-decide whether an observation is removed.}
+decide whether an observation is removed. Defaults to \code{3}, unlike the
+over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -41,7 +41,8 @@ been estimated.}
 be populated (eventually) by the \code{...} selectors.}
 
 \item{neighbors}{An integer. Number of nearest neighbor that are used to
-decide whether an observation is removed.}
+decide whether an observation is removed. Defaults to \code{3}, unlike the
+over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
@@ -125,9 +126,10 @@ columns \code{terms} and \code{id}:
 }
 
 \section{Tuning Parameters}{
-This step has 1 tuning parameters:
+This step has 2 tuning parameters:
 \itemize{
 \item \code{neighbors}: # Nearest Neighbors (type: integer, default: 3)
+\item \code{all_k}: Pruning (type: logical, default: FALSE)
 }
 }
 

--- a/man/step_ncl.Rd
+++ b/man/step_ncl.Rd
@@ -40,7 +40,8 @@ been estimated.}
 be populated (eventually) by the \code{...} selectors.}
 
 \item{neighbors}{An integer. Number of nearest neighbor that are used to
-decide whether an observation is removed.}
+decide whether an observation is removed. Defaults to \code{3}, unlike the
+over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
@@ -116,9 +117,10 @@ columns \code{terms} and \code{id}:
 }
 
 \section{Tuning Parameters}{
-This step has 1 tuning parameters:
+This step has 2 tuning parameters:
 \itemize{
 \item \code{neighbors}: # Nearest Neighbors (type: integer, default: 3)
+\item \code{threshold_clean}: Threshold (type: double, default: 0.5)
 }
 }
 

--- a/man/step_smogn.Rd
+++ b/man/step_smogn.Rd
@@ -121,9 +121,10 @@ columns \code{terms} and \code{id}:
 }
 
 \section{Tuning Parameters}{
-This step has 1 tuning parameters:
+This step has 2 tuning parameters:
 \itemize{
 \item \code{neighbors}: # Nearest Neighbors (type: integer, default: 5)
+\item \code{threshold}: Threshold (type: double, default: 0.5)
 }
 }
 

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -128,9 +128,10 @@
 ---
 
     Code
-      step_enn(recipe(class ~ x + y, data = circle_example), class, all_k = 1)
+      prep(step_enn(recipe(class ~ x + y, data = circle_example), class, all_k = 1))
     Condition
       Error in `step_enn()`:
+      Caused by error in `prep()`:
       ! `all_k` must be `TRUE` or `FALSE`, not the number 1.
 
 # unused outcome levels are skipped with a warning (#238)

--- a/tests/testthat/_snaps/smotenc.md
+++ b/tests/testthat/_snaps/smotenc.md
@@ -90,6 +90,16 @@
       Error in `step_smotenc()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+# errors on unsupported predictor types
+
+    Code
+      prep(step_smotenc(recipe(class ~ ., data = df), class))
+    Condition
+      Error in `step_smotenc()`:
+      Caused by error in `prep()`:
+      x All columns selected for the step should be double, integer, or nominal.
+      * 1 date variable found: `y`
+
 # unused outcome levels are skipped with a warning (#238)
 
     Code

--- a/tests/testthat/test-bsmote.R
+++ b/tests/testthat/test-bsmote.R
@@ -425,6 +425,7 @@ test_that("tunable", {
     step_bsmote(all_predictors())
   rec_param <- tunable.step_bsmote(rec$steps[[1]])
   expect_equal(rec_param$name, c("over_ratio", "neighbors", "all_neighbors"))
+  expect_equal(rec_param$call_info[[2]]$range, c(1, 10))
   expect_true(all(rec_param$source == "recipe"))
   expect_true(is.list(rec_param$call_info))
   expect_equal(nrow(rec_param), 3)

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -333,8 +333,9 @@ test_that("tunable", {
     step_enn(class)
 
   tune_args <- tunable(rec$steps[[1]])
-  expect_equal(tune_args$name, "neighbors")
-  expect_equal(nrow(tune_args), 1L)
+  expect_equal(tune_args$name, c("neighbors", "all_k"))
+  expect_equal(nrow(tune_args), 2L)
+  expect_equal(tune_args$call_info[[1]]$range, c(1, 10))
 })
 
 test_that("bad args", {
@@ -358,7 +359,8 @@ test_that("bad args", {
   expect_snapshot(
     error = TRUE,
     recipe(class ~ x + y, data = circle_example) |>
-      step_enn(class, all_k = 1)
+      step_enn(class, all_k = 1) |>
+      prep()
   )
 })
 

--- a/tests/testthat/test-ncl.R
+++ b/tests/testthat/test-ncl.R
@@ -312,8 +312,9 @@ test_that("tunable", {
     step_ncl(class)
 
   tune_args <- tunable(rec$steps[[1]])
-  expect_equal(tune_args$name, "neighbors")
-  expect_equal(nrow(tune_args), 1L)
+  expect_equal(tune_args$name, c("neighbors", "threshold_clean"))
+  expect_equal(nrow(tune_args), 2L)
+  expect_equal(tune_args$call_info[[1]]$range, c(1, 10))
 })
 
 test_that("bad args", {

--- a/tests/testthat/test-smogn.R
+++ b/tests/testthat/test-smogn.R
@@ -158,10 +158,10 @@ test_that("tunable", {
   rec <- recipe(mpg ~ ., data = mtcars) |>
     step_smogn(mpg)
   rec_param <- tunable.step_smogn(rec$steps[[1]])
-  expect_equal(rec_param$name, c("neighbors"))
+  expect_equal(rec_param$name, c("neighbors", "threshold"))
   expect_true(all(rec_param$source == "recipe"))
   expect_true(is.list(rec_param$call_info))
-  expect_equal(nrow(rec_param), 1)
+  expect_equal(nrow(rec_param), 2)
   expect_equal(
     names(rec_param),
     c("name", "call_info", "source", "component", "component_id")

--- a/tests/testthat/test-smotenc.R
+++ b/tests/testthat/test-smotenc.R
@@ -339,6 +339,20 @@ test_that("bad args", {
   )
 })
 
+test_that("errors on unsupported predictor types", {
+  df <- data.frame(
+    class = factor(rep(c("a", "b"), c(20, 5))),
+    x = rnorm(25),
+    y = as.Date("2020-01-01") + 1:25
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ ., data = df) |>
+      step_smotenc(class) |>
+      prep()
+  )
+})
+
 test_that("tunable is setup to works with extract_parameter_set_dials", {
   skip_if_not_installed("dials")
   rec <- recipe(~., data = mtcars) |>

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -274,6 +274,7 @@ test_that("tunable", {
     step_svmsmote(all_predictors())
   rec_param <- tunable.step_svmsmote(rec$steps[[1]])
   expect_equal(rec_param$name, c("over_ratio", "neighbors"))
+  expect_equal(rec_param$call_info[[2]]$range, c(1, 10))
   expect_true(all(rec_param$source == "recipe"))
   expect_true(is.list(rec_param$call_info))
   expect_equal(nrow(rec_param), 2)


### PR DESCRIPTION
Closes #254

Addresses the grab-bag of `tunable`/argument-consistency issues from #254, one concern per commit.

## Done

- `step_bsmote()` and `step_svmsmote()` now set `range = c(1, 10)` on their `neighbors` tunable, matching every other step that tunes `neighbors`.
- Documented that `neighbors` defaults to `3` on `step_enn()`/`step_ncl()` (vs `5` on the over-samplers). Default values are unchanged.
- Exposed additional tunables where a suitable dials parameter exists: `step_enn()` `all_k` (via `dials::prune()`), `step_ncl()` `threshold_clean` (via `dials::threshold()`), and `step_smogn()` `threshold` (via `dials::threshold()`).
- `step_upsample_new()` now orders `skip, seed, id` in its `step()` call to match every other step.
- `step_enn()` now validates `all_k` in `prep()` alongside `times`, instead of in the constructor.
- `step_smotenc()` now validates predictor types in `prep()`, erroring on unsupported types (e.g. dates) instead of failing later; numeric and nominal predictors are allowed.

## Skipped (with rationale)

- `distance_with` parity for over-samplers: skipped as a large/risky change. Over-samplers build synthetic points from nearest neighbors over all predictors; restricting the distance columns while still populating all columns would require reworking each `*_impl()` function. Left for a dedicated PR.
- `step_enn()` `times` and `step_smogn()` `perturbation` tunables: skipped because dials has no suitable parameter (no "number of repetitions" or "noise magnitude" param).
- Deprecated `ratio` argument position in `step_downsample()`/`step_upsample()`: left alone to preserve back-compat, as instructed.

## Testing note

PR #274 (`tests/testthat/test-tunable.R`) is not merged into this branch, so that file does not exist here. Tunable assertions were added/updated in the relevant step test files instead (including new `range = c(1, 10)` checks for bsmote/svmsmote). When #274 merges, its `test-tunable.R` will need the bsmote/svmsmote `neighbors` ranges updated to `c(1, 10)` to reflect this change.

Full test suite passes (`FAIL 0 | WARN 0 | SKIP 0 | PASS 1230`).