### PR TITLE
In-source documentation fixes (docs Phase 2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,65 @@
 # themis (development version)
 
+## New steps
+
+* `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
+
+* `step_enn()` (and its direct-implementation counterpart `enn()`) was added. It cleans the data using the Edited Nearest Neighbors rule, removing observations whose class differs from the majority of their nearest neighbors (#115).
+
+* `step_instance_hardness()` (and its direct-implementation counterpart `instance_hardness()`) was added. It under-samples the majority classes by removing the observations that are hardest to classify, estimated using the k-Disagreeing Neighbors measure (#172).
+
+* `step_ncl()` (and its direct-implementation counterpart `ncl()`) was added. It cleans the data using the Neighborhood Cleaning Rule, removing majority class observations that are noisy or that pollute the neighborhood of minority class observations (#116).
+
+* `step_oss()` (and its direct-implementation counterpart `oss()`) was added. It under-samples the majority classes using One-Sided Selection, combining Condensed Nearest Neighbors to reduce redundant majority class observations with Tomek's links to remove majority class observations on the decision boundary (#114).
+
+* `step_smogn()` (and its direct-implementation counterpart `smogn()`) was added. It over-samples rare regions of a numeric outcome for imbalanced regression using a combination of SMOTE-style interpolation and Gaussian noise, while under-sampling common regions (#49).
+
+* `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
+
+* `step_svmsmote()` (and its direct-implementation counterpart `svmsmote()`) was added. It over-samples the minority classes near the decision boundary by fitting a support vector machine and generating new examples around the minority class support vectors, interpolating toward minority neighbors where majority neighbors dominate the boundary and extrapolating outward where the support vector sits in a dense minority region (#170).
+
+## Improvements
+
+* Added a new article explaining how `over_ratio` and `under_ratio` work (#141).
+
+* Added standalone `rose()` function as a thin wrapper around `ROSE::ROSE()`, making it consistent with the other algorithms in the package that expose a direct implementation alongside their recipe step (#195).
+
+* All upsampling steps gain an `indicator_column` argument. When set, a logical column is added to the baked data marking rows added by the step (`TRUE`) vs rows from the original data (`FALSE`). For `step_rose()`, all rows are `TRUE` since ROSE generates a fully synthetic dataset (#58).
+
+* `step_adasyn()`, `step_cnn()`, and `step_oss()` (and their direct-implementation counterparts `adasyn()`, `cnn()`, and `oss()`) are now faster on large data. `step_adasyn()` computes the full-data nearest neighbors only for the minority observations it needs, and `step_cnn()`/`step_oss()` compute the condensation nearest neighbors for all candidates in one batch per store change instead of once per candidate. Results are unchanged (#257).
+
+* `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).
+
+* `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_smotenc()` now document the minimum number of observations needed to perform the algorithm (#104).
+
+* `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
+
+* `step_enn()` (and its direct-implementation counterpart `enn()`) gain a `times` argument to apply the cleaning repeatedly, stopping early on convergence, which corresponds to Repeated Edited Nearest Neighbors (RENN) (#173).
+
+* `step_enn()` (and its direct-implementation counterpart `enn()`) gain an `all_k` argument to apply the cleaning with an increasing number of neighbors, from 1 up to `neighbors`, which corresponds to All k-Nearest Neighbors (AllKNN) (#174).
+
+* `step_enn()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `all_k` as a tunable parameter (#254).
+
+* `step_ncl()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `threshold_clean` as a tunable parameter (#254).
+
+* `step_nearmiss()` and `step_tomek()` gain a `distance_with` argument to control which variables are used for distance calculations. This allows the steps to be used when non-numeric predictor variables are present in the data (#166).
+
+* `step_rose()` now validates predictor types during `prep()`, giving a clear error for unsupported types consistent with the other sampling steps instead of relying on `ROSE::ROSE()` to fail downstream (#265).
+
+* `step_rose()` and `rose()` now have improved documentation for `minority_prop`, clarifying that it controls the proportion of synthetic observations from the minority class, and how it differs from `over_ratio` (#144).
+
+* `step_rose()` (and its direct-implementation counterpart `rose()`) now validate that `minority_prop` is at most 1, since it is a proportion (#269).
+
+* `step_smogn()` now exposes `threshold` as a tunable parameter (#254).
+
+* `step_smoten()` now gains an `indicator_column` argument for parity with the other over-sampling steps. When set, a logical column is added to the baked data marking synthetic rows (#253).
+
+* `step_smotenc()` now validates that all predictors are numeric or nominal, erroring on unsupported column types such as dates instead of failing later (#254).
+
+* `step_svmsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
+
+## Bug fixes
+
 * Over-sampling steps (`step_smote()`, `step_adasyn()`, `step_bsmote()`, `step_svmsmote()`, `step_smoten()`, `step_smotenc()`, `step_rose()`, and `step_smogn()`) now error when supplied a case weights column instead of silently filling synthetic rows' weights with `NA`. These steps have never supported case weights (#243).
 
 * All sampling steps now handle an unused (zero-count) factor level in the outcome gracefully, dropping it with a warning before computing sampling targets instead of deleting all rows or erroring (#238).
@@ -12,83 +72,29 @@
 
 * `step_adasyn()` (and its direct-implementation counterpart `adasyn()`) no longer errors with a cryptic message when a minority class is well separated from the majority classes; it now falls back to uniform sampling and checks the minority class size before sampling (#240).
 
-* `step_adasyn()`, `step_cnn()`, and `step_oss()` (and their direct-implementation counterparts `adasyn()`, `cnn()`, and `oss()`) are now faster on large data. `step_adasyn()` computes the full-data nearest neighbors only for the minority observations it needs, and `step_cnn()`/`step_oss()` compute the condensation nearest neighbors for all candidates in one batch per store change instead of once per candidate. Results are unchanged (#257).
-
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) now selects the correct "danger" observations on the class border. The danger criterion had inverted the roles of minority and majority neighbors, causing it to oversample safe interior points instead of borderline ones (#235).
 
 * `step_bsmote()` (and its direct-implementation counterpart `bsmote()`) with `all_neighbors = TRUE` now seeds synthetic points only from minority-class danger observations and takes a reduced step toward majority-class neighbors, matching borderline-SMOTE2. Previously it could seed from border-adjacent majority rows, generating minority-labeled points around majority centers (#242).
 
-* `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
-
-* `step_cnn()` (and its direct-implementation counterpart `cnn()`) was added. It under-samples the majority classes using Condensed Nearest Neighbors, keeping only a consistent subset of observations that correctly classifies the data using a 1-nearest-neighbor rule (#113).
-
 * `step_cnn()`, `step_oss()`, and `step_smogn()` (and their direct-implementation counterparts `cnn()`, `oss()`, and `smogn()`) now sample correctly when only one candidate remains. A length-1 vector passed to `sample()` was interpreted as a count and sampled from `1:n`, which could select the wrong observations (#245).
 
-* `step_enn()` (and its direct-implementation counterpart `enn()`) was added. It cleans the data using the Edited Nearest Neighbors rule, removing observations whose class differs from the majority of their nearest neighbors (#115).
-
-* `step_enn()` (and its direct-implementation counterpart `enn()`) gain a `times` argument to apply the cleaning repeatedly, stopping early on convergence, which corresponds to Repeated Edited Nearest Neighbors (RENN) (#173).
-
-* `step_enn()` (and its direct-implementation counterpart `enn()`) gain an `all_k` argument to apply the cleaning with an increasing number of neighbors, from 1 up to `neighbors`, which corresponds to All k-Nearest Neighbors (AllKNN) (#174).
-
-* `step_enn()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `all_k` as a tunable parameter (#254).
-
-* `step_instance_hardness()` (and its direct-implementation counterpart `instance_hardness()`) was added. It under-samples the majority classes by removing the observations that are hardest to classify, estimated using the k-Disagreeing Neighbors measure (#172).
-
-* `step_ncl()` (and its direct-implementation counterpart `ncl()`) was added. It cleans the data using the Neighborhood Cleaning Rule, removing majority class observations that are noisy or that pollute the neighborhood of minority class observations (#116).
-
 * `step_ncl()` (and its direct-implementation counterpart `ncl()`) now treats a majority class whose size is exactly `threshold_clean` times the minority size as eligible for cleaning, using the `>=` comparison from Laurikkala (2001) instead of a strict `>` (#250).
-
-* `step_ncl()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `threshold_clean` as a tunable parameter (#254).
 
 * `step_nearmiss()` (and its direct-implementation counterpart `nearmiss()`) now keeps the majority observations that are genuinely closest to the minority class, rather than selecting rows by their position in the data (#236).
 
 * `step_nearmiss()` and `step_smogn()` (and their direct-implementation counterparts `nearmiss()` and `smogn()`) now return true cosine-distance magnitudes with `distance = "cosine"`. Previously the cosine branch L2-normalized and took Euclidean distances, returning `sqrt(2 - 2 * cos_sim)` instead of `1 - cos_sim`. Neighbor ordering was unaffected, but NearMiss neighbor-distance averages and SMOGN's interpolate-vs-noise threshold used the wrong magnitudes (#244).
 
-* `step_oss()` (and its direct-implementation counterpart `oss()`) was added. It under-samples the majority classes using One-Sided Selection, combining Condensed Nearest Neighbors to reduce redundant majority class observations with Tomek's links to remove majority class observations on the decision boundary (#114).
-
 * `step_oss()` (and its direct-implementation counterpart `oss()`) now condenses the majority classes with a single pass, matching Kubat & Matwin (1997), instead of iterating Condensed Nearest Neighbors to convergence, which removed more observations than the reference (#250).
-
-* `step_smogn()` (and its direct-implementation counterpart `smogn()`) was added. It over-samples rare regions of a numeric outcome for imbalanced regression using a combination of SMOTE-style interpolation and Gaussian noise, while under-sampling common regions (#49).
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) now emits a clear early error when automatic relevance is requested for a degenerate outcome (zero interquartile range or heavily tied values), pointing users to the `relevance` argument instead of aborting deep inside the boxplot-based computation (#264).
 
 * `step_smogn()` (and its direct-implementation counterpart `smogn()`) now scales the Gaussian perturbation of unsafe cases by each feature's standard deviation and caps the perturbation amount at the safe distance, using `sd * min(perturbation, maxD)` as in the reference, instead of scaling by a distance-capped standard deviation (#250).
 
-* `step_smogn()` now exposes `threshold` as a tunable parameter (#254).
-
-* `step_smoten()` (and its direct-implementation counterpart `smoten()`) was added. It over-samples the minority classes for data sets where all predictors are categorical, using the Value Difference Metric to find nearest neighbors and majority voting to generate new examples (#54).
-
-* `step_smoten()` now gains an `indicator_column` argument for parity with the other over-sampling steps. When set, a logical column is added to the baked data marking synthetic rows (#253).
-
 * `step_smotenc()` (and its direct-implementation counterpart `smotenc()`) now sets each synthetic sample's nominal features to the majority vote across the seed's k nearest neighbors, matching the SMOTENC algorithm, rather than voting over the randomly chosen interpolation partners (#241).
-
-* `step_smotenc()` now validates that all predictors are numeric or nominal, erroring on unsupported column types such as dates instead of failing later (#254).
-
-* `step_svmsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
 
 * `step_tomek()` (and its direct-implementation counterpart `tomek()`) now removes only the majority-class member of each Tomek link, retaining the minority-class member, matching the documented behavior. Previously it removed both members of the pair (#262).
 
-* `step_svmsmote()` (and its direct-implementation counterpart `svmsmote()`) was added. It over-samples the minority classes near the decision boundary by fitting a support vector machine and generating new examples around the minority class support vectors, interpolating in dense regions and extrapolating in sparse ones (#170).
-
 * `step_upsample()` now names itself, rather than `step_downsample()`, in the deprecation message shown when the defunct `ratio` argument is supplied (#252).
-
-* `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).
-
-* Added a new article explaining how `over_ratio` and `under_ratio` work (#141).
-
-* All upsampling steps gain an `indicator_column` argument. When set, a logical column is added to the baked data marking rows added by the step (`TRUE`) vs rows from the original data (`FALSE`). For `step_rose()`, all rows are `TRUE` since ROSE generates a fully synthetic dataset (#58).
-
-* `step_rose()` now validates predictor types during `prep()`, giving a clear error for unsupported types consistent with the other sampling steps instead of relying on `ROSE::ROSE()` to fail downstream (#265).
-
-* `step_rose()` and `rose()` now have improved documentation for `minority_prop`, clarifying that it controls the proportion of synthetic observations from the minority class, and how it differs from `over_ratio` (#144).
-
-* `step_rose()` (and its direct-implementation counterpart `rose()`) now validate that `minority_prop` is at most 1, since it is a proportion (#269).
-
-* Added standalone `rose()` function as a thin wrapper around `ROSE::ROSE()`, making it consistent with the other algorithms in the package that expose a direct implementation alongside their recipe step (#195).
-
-* `step_nearmiss()` and `step_tomek()` gain a `distance_with` argument to control which variables are used for distance calculations. This allows the steps to be used when non-numeric predictor variables are present in the data (#166).
-
-* `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_smotenc()` now document the minimum number of observations needed to perform the algorithm (#104).
 
 * All `step_*()` functions now correctly handle 0 and 1 row inputs in `bake()` (#160).
 

--- a/R/bsmote.R
+++ b/R/bsmote.R
@@ -1,4 +1,4 @@
-#' Apply borderline-SMOTE Algorithm
+#' Apply Borderline-SMOTE Algorithm
 #'
 #' `step_bsmote()` creates a *specification* of a recipe step that generate new
 #' examples of the minority class using nearest neighbors of these cases in the
@@ -18,8 +18,7 @@
 #' @param all_neighbors Type of two borderline-SMOTE method. Defaults to FALSE.
 #'  See details.
 #' @inheritParams step_smote
-#' @param seed An integer that will be used as the seed when
-#' smote-ing.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/bsmote_impl.R
+++ b/R/bsmote_impl.R
@@ -1,4 +1,4 @@
-#' borderline-SMOTE Algorithm
+#' Borderline-SMOTE Algorithm
 #'
 #' BSMOTE generates new examples of the minority class using nearest
 #'  neighbors of these cases in the border region between classes.

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -24,7 +24,7 @@
 #' @param ratio Deprecated argument; same as `under_ratio`
 #' @param target An integer that will be used to subsample. This
 #'  should not be set by the user and will be populated by `prep`.
-#' @param seed An integer that will be used as the seed when downsampling.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/enn.R
+++ b/R/enn.R
@@ -46,6 +46,11 @@
 #'  option `skip = TRUE` so that the extra sampling is _not_
 #'  conducted outside of the training set.
 #'
+#' # Minimum observations
+#'
+#' The data must have at least `neighbors + 1` observations for the nearest
+#' neighbors to be computed.
+#'
 #' # Tidying
 #'
 #' When you [`tidy()`][recipes::tidy.recipe()] this step, a tibble is returned with

--- a/R/instance_hardness.R
+++ b/R/instance_hardness.R
@@ -40,6 +40,11 @@
 #'  option `skip = TRUE` so that the extra sampling is _not_
 #'  conducted outside of the training set.
 #'
+#' # Minimum observations
+#'
+#' The data must have at least `neighbors + 1` observations for the nearest
+#' neighbors to be computed.
+#'
 #' # Tidying
 #'
 #' When you [`tidy()`][recipes::tidy.recipe()] this step, a tibble is returned with

--- a/R/instance_hardness.R
+++ b/R/instance_hardness.R
@@ -94,8 +94,8 @@
 #'   count(class, name = "baked")
 #' baked
 #'
-#' # Note that if the original data contained more rows than the
-#' # target n (= ratio * majority_n), the data are left alone:
+#' # Note that if the original data contained fewer rows than the
+#' # target n (= ratio * minority_n), the data are left alone:
 #' orig |>
 #'   left_join(training, by = "class") |>
 #'   left_join(baked, by = "class")

--- a/R/ncl.R
+++ b/R/ncl.R
@@ -41,6 +41,11 @@
 #'  option `skip = TRUE` so that the extra sampling is _not_
 #'  conducted outside of the training set.
 #'
+#' # Minimum observations
+#'
+#' The data must have at least `neighbors + 1` observations for the nearest
+#' neighbors to be computed.
+#'
 #' # Tidying
 #'
 #' When you [`tidy()`][recipes::tidy.recipe()] this step, a tibble is returned with

--- a/R/nearmiss.R
+++ b/R/nearmiss.R
@@ -99,8 +99,8 @@
 #'   count(class, name = "baked")
 #' baked
 #'
-#' # Note that if the original data contained more rows than the
-#' # target n (= ratio * majority_n), the data are left alone:
+#' # Note that if the original data contained fewer rows than the
+#' # target n (= ratio * minority_n), the data are left alone:
 #' orig |>
 #'   left_join(training, by = "class") |>
 #'   left_join(baked, by = "class")

--- a/R/rose.R
+++ b/R/rose.R
@@ -28,8 +28,7 @@
 #'  string is given, a logical column with that name is added to the output.
 #'  Because ROSE generates a fully synthetic dataset, all rows are marked
 #'  `TRUE`.
-#' @param seed An integer that will be used as the seed when
-#' rose-ing.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/smogn.R
+++ b/R/smogn.R
@@ -22,11 +22,8 @@
 #'  to generate the new examples of the rare values.
 #' @param perturbation A number. The magnitude of the Gaussian noise added when
 #'  generating synthetic examples in unsafe regions. Defaults to `0.02`.
-#' @param distance A character string specifying the distance metric used for
-#'  nearest neighbor calculations. One of `"euclidean"` (default), `"cosine"`,
-#'  `"mahalanobis"`, `"manhattan"`, or `"chebyshev"`.
-#' @param seed An integer that will be used as the seed when
-#' applying SMOGN.
+#' @inheritParams step_smote
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/smote.R
+++ b/R/smote.R
@@ -21,8 +21,7 @@
 #'  the RANN package and scale well to large datasets. `"manhattan"` and
 #'  `"chebyshev"` compute an exact O(n^2) distance matrix and may be slow for
 #'  large datasets.
-#' @param seed An integer that will be used as the seed when
-#' smote-ing.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/smoten.R
+++ b/R/smoten.R
@@ -1,4 +1,4 @@
-#' Apply SMOTEN algorithm
+#' Apply SMOTEN Algorithm
 #'
 #' `step_smoten()` creates a *specification* of a recipe step that generate new
 #' examples of the minority class using nearest neighbors of these cases, for
@@ -17,8 +17,7 @@
 #'  be populated (eventually) by the `...` selectors.
 #' @param neighbors An integer. Number of nearest neighbor that are used
 #'  to generate the new examples of the minority class.
-#' @param seed An integer that will be used as the seed when
-#' smote-ing.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/smoten.R
+++ b/R/smoten.R
@@ -42,6 +42,16 @@
 #' Each minority class must have at least `neighbors + 1` observations to
 #' perform the SMOTEN algorithm.
 #'
+#' # Value Difference Metric
+#'
+#' The Value Difference Metric (VDM) used here deviates from Chawla's stated
+#' form in two ways. The per-feature deltas are aggregated by summing them
+#' (`r = 1`) rather than by taking their Euclidean norm (`r = 2`), and when a
+#' synthetic value is chosen by majority vote of the nearest neighbors the seed
+#' observation itself is excluded from the vote. The metric is internally
+#' consistent and is a valid VDM variant, but be aware of these choices when
+#' comparing results with other implementations.
+#'
 #' # Tidying
 #'
 #' When you [`tidy()`][recipes::tidy.recipe()] this step, a tibble is returned with

--- a/R/smotenc.R
+++ b/R/smotenc.R
@@ -1,4 +1,4 @@
-#' Apply SMOTENC algorithm
+#' Apply SMOTENC Algorithm
 #'
 #' `step_smotenc()` creates a *specification* of a recipe step that generate new
 #' examples of the minority class using nearest neighbors of these cases.
@@ -16,8 +16,7 @@
 #'  be populated (eventually) by the `...` selectors.
 #' @param neighbors An integer. Number of nearest neighbor that are used
 #'  to generate the new examples of the minority class.
-#' @param seed An integer that will be used as the seed when
-#' smote-ing.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/svmsmote.R
+++ b/R/svmsmote.R
@@ -16,8 +16,7 @@
 #' @param neighbors An integer. Number of nearest neighbor that are used
 #'  to generate the new examples of the minority class.
 #' @inheritParams step_smote
-#' @param seed An integer that will be used as the seed when
-#' smote-ing.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/R/tomek.R
+++ b/R/tomek.R
@@ -1,4 +1,4 @@
-#' Remove Tomek’s Links
+#' Remove Tomek's Links
 #'
 #' `step_tomek()` creates a *specification* of a recipe step that removes
 #' majority class instances of tomek links.

--- a/R/tomek_impl.R
+++ b/R/tomek_impl.R
@@ -1,4 +1,4 @@
-#' Remove Tomek's links
+#' Remove Tomek's Links
 #'
 #' Removes the majority class member of each pair of observations that form a
 #' Tomek link.

--- a/R/upsample.R
+++ b/R/upsample.R
@@ -28,7 +28,7 @@
 #'  string is given, a logical column with that name is added to the output,
 #'  marking rows added by the step (`TRUE`) vs rows from the original data
 #'  (`FALSE`).
-#' @param seed An integer that will be used as the seed when upsampling.
+#' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -75,3 +75,6 @@ reference:
 - title: Datasets
   contents:
   - circle_example
+- title: Developer tools
+  contents:
+  - required_pkgs.step_adasyn

--- a/man-roxygen/details-nearmiss.R
+++ b/man-roxygen/details-nearmiss.R
@@ -2,3 +2,8 @@
 #' This implements the NearMiss-1 algorithm. It retains the points from the
 #' majority class which have the smallest mean distance to the nearest points
 #' in the minority class.
+#'
+#' With more than two classes, the mean distance is computed to the nearest
+#' points across all other classes, not only the minority class. This differs
+#' from imbalanced-learn, which measures distance to the minority class only.
+#' The binary case, the primary intended use, is unaffected.

--- a/man-roxygen/details-oss.R
+++ b/man-roxygen/details-oss.R
@@ -10,3 +10,7 @@
 #' The smallest class is treated as the minority class and is always kept.
 #' Because the CNN step relies on a random seed observation and a random scan
 #' order, results depend on the random seed.
+#'
+#' With more than two classes, the Tomek's links step removes both members of a
+#' majority-majority link, not only links between a majority and the minority
+#' class. The binary case, the primary intended use, is unaffected.

--- a/man/bsmote.Rd
+++ b/man/bsmote.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/bsmote_impl.R
 \name{bsmote}
 \alias{bsmote}
-\title{borderline-SMOTE Algorithm}
+\title{Borderline-SMOTE Algorithm}
 \usage{
 bsmote(
   df,

--- a/man/nearmiss.Rd
+++ b/man/nearmiss.Rd
@@ -42,6 +42,11 @@ This implements the NearMiss-1 algorithm. It retains the points from the
 majority class which have the smallest mean distance to the nearest points
 in the minority class.
 
+With more than two classes, the mean distance is computed to the nearest
+points across all other classes, not only the minority class. This differs
+from imbalanced-learn, which measures distance to the minority class only.
+The binary case, the primary intended use, is unaffected.
+
 All columns used in this function must be numeric with no missing data.
 }
 \examples{

--- a/man/oss.Rd
+++ b/man/oss.Rd
@@ -42,6 +42,10 @@ The smallest class is treated as the minority class and is always kept.
 Because the CNN step relies on a random seed observation and a random scan
 order, results depend on the random seed.
 
+With more than two classes, the Tomek's links step removes both members of a
+majority-majority link, not only links between a majority and the minority
+class. The binary case, the primary intended use, is unaffected.
+
 All columns used in this function must be numeric with no missing data.
 }
 \examples{

--- a/man/smogn.Rd
+++ b/man/smogn.Rd
@@ -36,7 +36,11 @@ generating synthetic examples in unsafe regions. Defaults to \code{0.02}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}.}
+\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
+\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
+the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
+large datasets.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/step_bsmote.Rd
+++ b/man/step_bsmote.Rd
@@ -3,7 +3,7 @@
 \name{step_bsmote}
 \alias{step_bsmote}
 \alias{tidy.step_bsmote}
-\title{Apply borderline-SMOTE Algorithm}
+\title{Apply Borderline-SMOTE Algorithm}
 \usage{
 step_bsmote(
   recipe,
@@ -72,8 +72,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-smote-ing.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_downsample.Rd
+++ b/man/step_downsample.Rd
@@ -57,7 +57,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when downsampling.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -115,6 +115,11 @@ When used in modeling, users should strongly consider using the
 option \code{skip = TRUE} so that the extra sampling is \emph{not}
 conducted outside of the training set.
 }
+\section{Minimum observations}{
+The data must have at least \code{neighbors + 1} observations for the nearest
+neighbors to be computed.
+}
+
 \section{Tidying}{
 When you \code{\link[recipes:tidy.recipe]{tidy()}} this step, a tibble is returned with
 columns \code{terms} and \code{id}:

--- a/man/step_instance_hardness.Rd
+++ b/man/step_instance_hardness.Rd
@@ -103,6 +103,11 @@ When used in modeling, users should strongly consider using the
 option \code{skip = TRUE} so that the extra sampling is \emph{not}
 conducted outside of the training set.
 }
+\section{Minimum observations}{
+The data must have at least \code{neighbors + 1} observations for the nearest
+neighbors to be computed.
+}
+
 \section{Tidying}{
 When you \code{\link[recipes:tidy.recipe]{tidy()}} this step, a tibble is returned with
 columns \code{terms} and \code{id}:

--- a/man/step_instance_hardness.Rd
+++ b/man/step_instance_hardness.Rd
@@ -157,8 +157,8 @@ baked <- up_rec |>
   count(class, name = "baked")
 baked
 
-# Note that if the original data contained more rows than the
-# target n (= ratio * majority_n), the data are left alone:
+# Note that if the original data contained fewer rows than the
+# target n (= ratio * minority_n), the data are left alone:
 orig |>
   left_join(training, by = "class") |>
   left_join(baked, by = "class")

--- a/man/step_ncl.Rd
+++ b/man/step_ncl.Rd
@@ -106,6 +106,11 @@ When used in modeling, users should strongly consider using the
 option \code{skip = TRUE} so that the extra sampling is \emph{not}
 conducted outside of the training set.
 }
+\section{Minimum observations}{
+The data must have at least \code{neighbors + 1} observations for the nearest
+neighbors to be computed.
+}
+
 \section{Tidying}{
 When you \code{\link[recipes:tidy.recipe]{tidy()}} this step, a tibble is returned with
 columns \code{terms} and \code{id}:

--- a/man/step_nearmiss.Rd
+++ b/man/step_nearmiss.Rd
@@ -90,6 +90,11 @@ This implements the NearMiss-1 algorithm. It retains the points from the
 majority class which have the smallest mean distance to the nearest points
 in the minority class.
 
+With more than two classes, the mean distance is computed to the nearest
+points across all other classes, not only the minority class. This differs
+from imbalanced-learn, which measures distance to the minority class only.
+The binary case, the primary intended use, is unaffected.
+
 All columns in the data are sampled and returned by \code{\link[recipes:juice]{recipes::juice()}}
 and \code{\link[recipes:bake]{recipes::bake()}}.
 
@@ -159,8 +164,8 @@ baked <- up_rec |>
   count(class, name = "baked")
 baked
 
-# Note that if the original data contained more rows than the
-# target n (= ratio * majority_n), the data are left alone:
+# Note that if the original data contained fewer rows than the
+# target n (= ratio * minority_n), the data are left alone:
 orig |>
   left_join(training, by = "class") |>
   left_join(baked, by = "class")

--- a/man/step_oss.Rd
+++ b/man/step_oss.Rd
@@ -85,6 +85,10 @@ The smallest class is treated as the minority class and is always kept.
 Because the CNN step relies on a random seed observation and a random scan
 order, results depend on the random seed.
 
+With more than two classes, the Tomek's links step removes both members of a
+majority-majority link, not only links between a majority and the minority
+class. The binary case, the primary intended use, is unaffected.
+
 All variables selected by \code{distance_with} must be numeric with no missing
 data.
 

--- a/man/step_rose.Rd
+++ b/man/step_rose.Rd
@@ -72,8 +72,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-rose-ing.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_smogn.Rd
+++ b/man/step_smogn.Rd
@@ -56,7 +56,11 @@ generating synthetic examples in unsafe regions. Defaults to \code{0.02}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}.}
+\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
+\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
+the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
+large datasets.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,
@@ -69,8 +73,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-applying SMOGN.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_smote.Rd
+++ b/man/step_smote.Rd
@@ -68,8 +68,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-smote-ing.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_smoten.Rd
+++ b/man/step_smoten.Rd
@@ -102,6 +102,16 @@ Each minority class must have at least \code{neighbors + 1} observations to
 perform the SMOTEN algorithm.
 }
 
+\section{Value Difference Metric}{
+The Value Difference Metric (VDM) used here deviates from Chawla's stated
+form in two ways. The per-feature deltas are aggregated by summing them
+(\code{r = 1}) rather than by taking their Euclidean norm (\code{r = 2}), and when a
+synthetic value is chosen by majority vote of the nearest neighbors the seed
+observation itself is excluded from the vote. The metric is internally
+consistent and is a valid VDM variant, but be aware of these choices when
+comparing results with other implementations.
+}
+
 \section{Tidying}{
 When you \code{\link[recipes:tidy.recipe]{tidy()}} this step, a tibble is returned with
 columns \code{terms} and \code{id}:
@@ -110,14 +120,11 @@ columns \code{terms} and \code{id}:
 \item{terms}{character, the selectors or variables selected}
 \item{id}{character, id of this step}
 }
-}
 
-\section{Tuning Parameters}{
-This step has 2 tuning parameters:
-\itemize{
-\item \code{over_ratio}: Over-Sampling Ratio (type: double, default: 1)
-\item \code{neighbors}: # Nearest Neighbors (type: integer, default: 5)
-}
+\if{html}{\out{<div class="sourceCode {r, echo = FALSE, results="asis"}">}}\preformatted{step <- "step_smoten"
+result <- knitr::knit_child("man/rmd/tunable-args.Rmd")
+cat(result)
+}\if{html}{\out{</div>}}
 }
 
 \section{Case weights}{

--- a/man/step_smoten.Rd
+++ b/man/step_smoten.Rd
@@ -3,7 +3,7 @@
 \name{step_smoten}
 \alias{step_smoten}
 \alias{tidy.step_smoten}
-\title{Apply SMOTEN algorithm}
+\title{Apply SMOTEN Algorithm}
 \usage{
 step_smoten(
   recipe,
@@ -59,8 +59,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-smote-ing.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_smotenc.Rd
+++ b/man/step_smotenc.Rd
@@ -3,7 +3,7 @@
 \name{step_smotenc}
 \alias{step_smotenc}
 \alias{tidy.step_smotenc}
-\title{Apply SMOTENC algorithm}
+\title{Apply SMOTENC Algorithm}
 \usage{
 step_smotenc(
   recipe,
@@ -59,8 +59,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-smote-ing.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_svmsmote.Rd
+++ b/man/step_svmsmote.Rd
@@ -68,8 +68,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when
-smote-ing.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/step_tomek.Rd
+++ b/man/step_tomek.Rd
@@ -3,7 +3,7 @@
 \name{step_tomek}
 \alias{step_tomek}
 \alias{tidy.step_tomek}
-\title{Remove Tomek’s Links}
+\title{Remove Tomek's Links}
 \usage{
 step_tomek(
   recipe,

--- a/man/step_upsample.Rd
+++ b/man/step_upsample.Rd
@@ -63,7 +63,7 @@ operations may not be able to be conducted on new data (e.g. processing the
 outcome variable(s)). Care should be taken when using \code{skip = TRUE} as it
 may affect the computations for subsequent operations.}
 
-\item{seed}{An integer that will be used as the seed when upsampling.}
+\item{seed}{An integer that will be used as the seed when applied.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 }

--- a/man/tomek.Rd
+++ b/man/tomek.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tomek_impl.R
 \name{tomek}
 \alias{tomek}
-\title{Remove Tomek's links}
+\title{Remove Tomek's Links}
 \usage{
 tomek(df, var, distance = "euclidean")
 }


### PR DESCRIPTION
Addresses the four in-source documentation issues. Each issue is its own commit.

- **#277** Corrects the misleading `target n (= ratio * majority_n)` example comment in `nearmiss.R` and `instance_hardness.R`. These are under-samplers, so the target derives from the minority/smallest-class count, and a class is left alone when it has *fewer* rows than the target, not more.
- **#273** Documents the two VDM design choices in `step_smoten()`: per-feature deltas aggregated with `r = 1` (sum, not Euclidean), and the seed excluded from the majority vote. Verified against `smoten_impl.R`.
- **#267** Documents the multiclass semantics of `step_nearmiss()` (distance measured to all other classes, unlike imbalanced-learn's minority-only) and `step_oss()` (majority-majority Tomek links remove both members), noting the binary case is unaffected.
- **#259** Consistency cleanups:
  - Adds `required_pkgs.step_adasyn` to the pkgdown reference index (`check_pkgdown()` flagged it).
  - Normalizes step title casing (`Borderline`, `SMOTEN`/`SMOTENC` `Algorithm`) and the Tomek title (straight apostrophe, `Links`) across `tomek.R`/`tomek_impl.R`.
  - Unifies `@param seed` wording to "...when applied." across all steps.
  - Replaces smogn's shorter re-documented `distance` param with `@inheritParams step_smote`.
  - Adds the "Minimum observations" section to `step_enn()`, `step_ncl()`, and `step_instance_hardness()`.
  - Regroups the NEWS dev section into New steps / Improvements / Bug fixes to match prior releases.
  - Fixes the backwards SVM-SMOTE NEWS wording (interpolation happens near the majority-dominated boundary, extrapolation in dense minority regions), verified against `svmsmote_impl.R`.

All 1351 tests pass. `pkgdown::check_pkgdown()` could not run locally (the `tidytemplate` template package is not installed), but the new reference entry matches the topic's `\name`.

Closes #277, closes #273, closes #267, closes #259.