### PR TITLE
Mirror method taxonomy in pkgdown reference (docs Phase 3, pkgdown)

### DIFF
--- a/R/enn.R
+++ b/R/enn.R
@@ -77,6 +77,10 @@
 #' Transactions on Systems, Man, and Cybernetics, (6), 448-452.
 #'
 #' @seealso [enn()] for direct implementation
+#'
+#'  [step_smote()], which is commonly composed before `step_enn()` to clean the
+#'  ambiguous points that over-sampling creates near the class boundary (the
+#'  equivalent of imbalanced-learn's `SMOTEENN`).
 #' @family Steps for under-sampling
 #'
 #' @export

--- a/R/smote.R
+++ b/R/smote.R
@@ -67,6 +67,11 @@
 #'  Journal of Artificial Intelligence Research, 16:321-357.
 #'
 #' @seealso [smote()] for direct implementation
+#'
+#'  [step_enn()] and [step_tomek()], which are commonly composed after
+#'  `step_smote()` to clean the ambiguous points that over-sampling creates
+#'  near the class boundary (the equivalent of imbalanced-learn's `SMOTEENN`
+#'  and `SMOTETomek`).
 #' @family Steps for over-sampling
 #'
 #' @export

--- a/R/tomek.R
+++ b/R/tomek.R
@@ -50,6 +50,10 @@
 #'  6:769-772, 1976.
 #'
 #' @seealso [tomek()] for direct implementation
+#'
+#'  [step_smote()], which is commonly composed before `step_tomek()` to clean
+#'  the ambiguous points that over-sampling creates near the class boundary
+#'  (the equivalent of imbalanced-learn's `SMOTETomek`).
 #' @family Steps for under-sampling
 #'
 #' @export

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,31 +27,51 @@ reference:
 - title: Over-sampling
   desc: >
     **Over-sampling** is the act of synthetically generating observations for
-    the minority classes. This is done either by random sampling or using
-    more advanced methods.
+    the minority classes, either by random replication or by more advanced
+    methods that synthesize new observations.
+- subtitle: Random replication
   contents:
   - step_upsample
+- subtitle: SMOTE family
+  contents:
   - step_smote
-  - step_smogn
-  - step_smotenc
-  - step_smoten
   - step_bsmote
   - step_svmsmote
+  - step_smotenc
+  - step_smoten
+- subtitle: Adaptive
+  contents:
   - step_adasyn
+- subtitle: Smoothed bootstrap
+  contents:
   - step_rose
 - title: Under-sampling
   desc: >
     **Under-sampling** is the act of removing observations from the majority
-    classes.
+    classes. Every under-sampler here uses *prototype selection*, keeping a
+    subset of the real rows, rather than *prototype generation*, which would
+    create new representative rows.
+- subtitle: Random
   contents:
-  - step_cnn
   - step_downsample
-  - step_enn
-  - step_instance_hardness
-  - step_ncl
+- subtitle: Distance / near-boundary
+  contents:
   - step_nearmiss
-  - step_oss
   - step_tomek
+  - step_cnn
+  - step_oss
+- subtitle: Neighborhood cleaning
+  contents:
+  - step_enn
+  - step_ncl
+- subtitle: Hardness
+  contents:
+  - step_instance_hardness
+- title: Regression
+  desc: >
+    Resampling an imbalanced numeric outcome rather than a class.
+  contents:
+  - step_smogn
 - title: Methods
   desc: >
     Some of the methods implemented in this package as steps are also

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -206,6 +206,10 @@ Transactions on Systems, Man, and Cybernetics, (6), 448-452.
 \seealso{
 \code{\link[=enn]{enn()}} for direct implementation
 
+\code{\link[=step_smote]{step_smote()}}, which is commonly composed before \code{step_enn()} to clean the
+ambiguous points that over-sampling creates near the class boundary (the
+equivalent of imbalanced-learn's \code{SMOTEENN}).
+
 Other Steps for under-sampling:
 \code{\link[=step_cnn]{step_cnn()}},
 \code{\link[=step_downsample]{step_downsample()}},

--- a/man/step_smote.Rd
+++ b/man/step_smote.Rd
@@ -187,6 +187,11 @@ Journal of Artificial Intelligence Research, 16:321-357.
 \seealso{
 \code{\link[=smote]{smote()}} for direct implementation
 
+\code{\link[=step_enn]{step_enn()}} and \code{\link[=step_tomek]{step_tomek()}}, which are commonly composed after
+\code{step_smote()} to clean the ambiguous points that over-sampling creates
+near the class boundary (the equivalent of imbalanced-learn's \code{SMOTEENN}
+and \code{SMOTETomek}).
+
 Other Steps for over-sampling:
 \code{\link[=step_adasyn]{step_adasyn()}},
 \code{\link[=step_bsmote]{step_bsmote()}},

--- a/man/step_tomek.Rd
+++ b/man/step_tomek.Rd
@@ -164,6 +164,10 @@ Tomek. Two modifications of cnn. IEEE Trans. Syst. Man Cybern.,
 \seealso{
 \code{\link[=tomek]{tomek()}} for direct implementation
 
+\code{\link[=step_smote]{step_smote()}}, which is commonly composed before \code{step_tomek()} to clean
+the ambiguous points that over-sampling creates near the class boundary
+(the equivalent of imbalanced-learn's \code{SMOTETomek}).
+
 Other Steps for under-sampling:
 \code{\link[=step_cnn]{step_cnn()}},
 \code{\link[=step_downsample]{step_downsample()}},


### PR DESCRIPTION
The pkgdown-side work for Phase 3, bundling the two config/reference changes that support the upcoming articles.

- **#321 (reference index)** Restructures the reference index to mirror the method taxonomy: over-sampling split into random replication / SMOTE family / adaptive / smoothed bootstrap, under-sampling split by prototype-selection kind (random / distance-near-boundary / neighborhood cleaning / hardness) with a note that every under-sampler selects real rows, and a dedicated Regression section for `step_smogn()`.
- **#319 (cross-references)** Adds `@seealso` cross-references between `step_smote()`, `step_enn()`, and `step_tomek()` describing the SMOTE + ENN / SMOTE + Tomek composition (the equivalent of imbalanced-learn's `SMOTEENN` / `SMOTETomek`).

The prose articles for #321 and #319 land in a separate vignette PR, which is where those issues are closed. `pkgdown::check_pkgdown()` cannot run locally (the `tidytemplate` template package is not installed), but the YAML parses and all 17 step topics remain present with no duplicates.

Refs #321, #319.