### PR TITLE
Add common-pitfalls article (docs Phase 3)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## Improvements
 
+* Added a new "Common pitfalls" article on resampling only the training set (`skip = TRUE`) and avoiding cross-validation leakage (#320).
+
 * Added a new article explaining how `over_ratio` and `under_ratio` work (#141).
 
 * Added standalone `rose()` function as a thin wrapper around `ROSE::ROSE()`, making it consistent with the other algorithms in the package that expose a direct implementation alongside their recipe step (#195).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -22,6 +22,7 @@ articles:
   navbar: ~
   contents:
   - articles/ratio
+  - articles/common-pitfalls
 
 reference:
 - title: Over-sampling

--- a/vignettes/articles/common-pitfalls.Rmd
+++ b/vignettes/articles/common-pitfalls.Rmd
@@ -1,0 +1,97 @@
+---
+title: "Common pitfalls"
+---
+
+```{r}
+#| include: false
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+Resampling is easy to misuse in ways that quietly inflate your performance estimates. This article covers the two mistakes that matter most, mirroring imbalanced-learn's [Common pitfalls and recommended practices](https://imbalanced-learn.org/stable/common_pitfalls.html) page. The short version: **resampling must only ever touch the training data**, and doing it before you split for validation leaks information across the split.
+
+```{r}
+#| message: false
+library(recipes)
+library(themis)
+```
+
+## Resample the training set only
+
+Every row-changing themis step defaults to `skip = TRUE`. This means the step runs during `prep()` and during `bake(new_data = NULL)` (the training data), but is *skipped* when new data is baked, such as when a workflow bakes the assessment set at `predict()` time. The data you evaluate on keeps its natural class balance.
+
+We can see this directly. Here is a small imbalanced training set and a held-out set:
+
+```{r}
+set.seed(1)
+train <- data.frame(
+  class = factor(rep(c("minority", "majority"), c(20, 180))),
+  x = rnorm(200),
+  y = rnorm(200)
+)
+test <- data.frame(
+  class = factor(rep(c("minority", "majority"), c(5, 45))),
+  x = rnorm(50),
+  y = rnorm(50)
+)
+
+rec <- recipe(class ~ x + y, data = train) |>
+  step_smote(class) |>
+  prep()
+```
+
+Baking the training data applies SMOTE, balancing the classes:
+
+```{r}
+bake(rec, new_data = NULL) |>
+  count(class)
+```
+
+Baking new data skips the step, so the held-out set keeps its natural, imbalanced distribution:
+
+```{r}
+bake(rec, new_data = test) |>
+  count(class)
+```
+
+This is exactly what you want: the model trains on balanced data, but is evaluated on the real class balance it will see in production. Leaving `skip = TRUE` (the default) is almost always correct.
+
+## Do not resample before splitting or cross-validation
+
+The most common leakage mistake is applying a sampling step to the *whole* data set before splitting it, for example running SMOTE and then calling `rsample::initial_split()` or `rsample::vfold_cv()`. Synthetic minority points are built by interpolating between real points, so a synthetic row can land in the analysis fold while the real rows it was derived from land in the assessment fold. The model then effectively sees the assessment data during training, and the resulting metrics are optimistic and unrealistic.
+
+```{r}
+#| eval: false
+# WRONG: resampling leaks across the cross-validation split
+resampled <- recipe(class ~ ., data = train) |>
+  step_smote(class) |>
+  prep() |>
+  bake(new_data = NULL)
+
+folds <- rsample::vfold_cv(resampled) # synthetic rows now span folds
+```
+
+The correct pattern is to put the step in a recipe inside a workflow, and let `tune::fit_resample()` or `tune::tune_grid()` apply it *inside each analysis fold only*. Because the step has `skip = TRUE`, it never touches the assessment fold.
+
+```{r}
+#| eval: false
+# CORRECT: resample the raw data, then apply the recipe inside each fold
+folds <- rsample::vfold_cv(train)
+
+rec <- recipe(class ~ ., data = train) |>
+  step_smote(class)
+
+wf <- workflows::workflow() |>
+  workflows::add_recipe(rec) |>
+  workflows::add_model(parsnip::logistic_reg())
+
+tune::fit_resamples(wf, folds)
+```
+
+Here SMOTE is fit on each analysis fold and skipped on each assessment fold, so metrics are computed on the natural class balance. This is the honest estimate, and it is usually noticeably lower than the leaky version, which is the point.
+
+## The imbalanced-learn parallel
+
+If you are coming from Python, this is the same guarantee that imbalanced-learn's `Pipeline` provides. There, a sampler's `fit_resample` runs during `fit` (on the training fold) and is bypassed at `predict`/`score`. In tidymodels, recipes' `skip = TRUE` plus a workflow gives you the identical "resample train, bypass test" behavior, without a special pipeline object.


### PR DESCRIPTION
Adds a `common-pitfalls` article mirroring imbalanced-learn's [Common pitfalls and recommended practices](https://imbalanced-learn.org/stable/common_pitfalls.html) page, aimed especially at users migrating from Python (#320).

Covers:
1. **Resample the training set only.** Explains `skip = TRUE` with a runnable demo: `bake(new_data = NULL)` applies SMOTE and balances the classes, while `bake(new_data = test)` skips the step and keeps the natural distribution.
2. **Do not resample before splitting or cross-validation.** A leaky-vs-correct pair of examples: resampling the whole data set before `vfold_cv()` leaks synthetic points across folds, versus putting the step in a recipe inside a workflow so `fit_resamples()` applies it inside each analysis fold only.
3. **The imbalanced-learn parallel.** recipes' `skip = TRUE` plus a workflow is the structural equivalent of imbalanced-learn's `Pipeline` "resample train, bypass test" behavior.

The `skip = TRUE` demonstration runs with only recipes + themis (both available). The cross-validation examples are shown as illustrative `eval = FALSE` code, since workflows/rsample/tune/parsnip are not themis dependencies. Registered in `_pkgdown.yml` and renders cleanly via `rmarkdown::render()`.

Closes #320.