### PR TITLE
Add probability-divergence distance metrics via a sqrt embedding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_tomek()` (and their direct-implementation counterparts `adasyn()`, `bsmote()`, `nearmiss()`, `smote()`, and `tomek()`) gain a `distance` argument to control which distance metric is used for nearest neighbor calculations. Supported metrics are `"euclidean"` (default), `"cosine"`, `"mahalanobis"`, `"manhattan"`, and `"chebyshev"` (#171).
 
+* The `distance` argument of every step that performs nearest neighbor calculations gains four probability-divergence metrics: `"squared_chord"`, `"matusita"`, `"hellinger"`, and `"bhattacharyya"`. These treat each row as a distribution over the predictors and so require non-negative values, with `"hellinger"` and `"bhattacharyya"` further requiring each row to sum to 1. All four run on the fast approximate nearest neighbor path and scale to large data (#234).
+
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_smotenc()` now document the minimum number of observations needed to perform the algorithm (#104).
 
 * `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).

--- a/R/misc.R
+++ b/R/misc.R
@@ -193,7 +193,14 @@ Mode <- function(x) {
 check_distance_arg <- function(distance, call = caller_env()) {
   rlang::arg_match(
     distance,
-    c("euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev"),
+    c(
+      "euclidean",
+      "cosine",
+      "mahalanobis",
+      "manhattan",
+      "chebyshev",
+      sqrt_embedded_metrics()
+    ),
     error_call = call
   )
 }
@@ -218,6 +225,24 @@ drop_self_neighbor <- function(idx) {
   out
 }
 
+# Probability-divergence metrics that equal Euclidean distance on the elementwise
+# square root of the data, either exactly or after a monotone transform of the
+# resulting distance (see `metric_rescale_dists()`). Because the transform is
+# monotone, a RANN search on the square-rooted coordinates returns exactly the
+# right neighbor *indices*; only distance magnitudes need converting.
+#
+# squared_chord and matusita hold for any non-negative rows. hellinger and
+# bhattacharyya are derived from the fidelity `1 - d^2 / 2`, an identity that
+# only holds when each row sums to one, so they additionally require rows to be
+# probability distributions.
+sqrt_embedded_metrics <- function() {
+  c("squared_chord", "matusita", "hellinger", "bhattacharyya")
+}
+
+simplex_metrics <- function() {
+  c("hellinger", "bhattacharyya")
+}
+
 # Metrics whose distance equals ordinary Euclidean distance after a per-row or
 # linear transform of the data, so the neighbor search can run on the transformed
 # coordinates via RANN. manhattan and chebyshev are not in this set: RANN only
@@ -227,7 +252,40 @@ drop_self_neighbor <- function(idx) {
 # routine whose tie-breaking could differ from `order()`/`sort()` and change
 # results, so the dense path is kept for these two metrics.
 metric_is_transformable <- function(distance) {
-  distance %in% c("euclidean", "cosine", "mahalanobis")
+  distance %in%
+    c("euclidean", "cosine", "mahalanobis", sqrt_embedded_metrics())
+}
+
+check_metric_nonnegative <- function(data, distance, call = caller_env()) {
+  if (any(data < 0)) {
+    cli::cli_abort(
+      c(
+        "{.code distance = \"{distance}\"} requires non-negative predictor values.",
+        i = "Negative values were found in the columns used to compute distances.",
+        i = "Each row is treated as a probability distribution by this metric.",
+        i = "Try a different {.arg distance} metric or rescale the predictors."
+      ),
+      call = call
+    )
+  }
+  invisible()
+}
+
+check_metric_simplex <- function(data, distance, call = caller_env()) {
+  bad <- abs(rowSums(data) - 1) > 1e-6
+  if (any(bad)) {
+    cli::cli_abort(
+      c(
+        "{.code distance = \"{distance}\"} requires each row to sum to 1.",
+        i = "{sum(bad)} row{?s} do{?es/} not sum to 1.",
+        i = "Each row is treated as a probability distribution by this metric.",
+        i = "Try {.code distance = \"matusita\"} or \\
+             {.code distance = \"squared_chord\"}, which do not require this."
+      ),
+      call = call
+    )
+  }
+  invisible()
 }
 
 # Transform `data` so that Euclidean distance on the result equals the requested
@@ -249,6 +307,13 @@ metric_transform <- function(
     norms[norms == 0] <- 1
     return(data / norms)
   }
+  if (distance %in% sqrt_embedded_metrics()) {
+    check_metric_nonnegative(data, distance, call = call)
+    if (distance %in% simplex_metrics()) {
+      check_metric_simplex(data, distance, call = call)
+    }
+    return(sqrt(data))
+  }
   if (distance == "mahalanobis") {
     if (check_singular && nrow(cov_data) <= ncol(cov_data)) {
       cli::cli_abort(
@@ -265,6 +330,27 @@ metric_transform <- function(
   }
   # euclidean: no transform needed
   data
+}
+
+# Convert Euclidean distances computed on `metric_transform()`ed coordinates into
+# the magnitudes of the requested metric. Each conversion is monotone increasing
+# in `d`, so this never reorders neighbors; it only matters for consumers such as
+# NearMiss that average per-neighbor distance values. Metrics whose transform is
+# already distance-preserving (euclidean, mahalanobis, matusita) fall through.
+metric_rescale_dists <- function(d, distance) {
+  switch(
+    distance,
+    # RANN returns Euclidean distances between unit vectors, sqrt(2 - 2*cos).
+    # Cosine distance is 1 - cos_sim = d^2 / 2.
+    "cosine" = d^2 / 2,
+    "squared_chord" = d^2,
+    "hellinger" = sqrt(2) * d,
+    # -log(fidelity), where fidelity = 1 - d^2 / 2. Rows with disjoint support
+    # give fidelity 0 and an infinite distance, which is correct; the `pmax()`
+    # only keeps floating-point error from pushing fidelity below 0 into NaN.
+    "bhattacharyya" = -log(pmax(1 - d^2 / 2, 0)),
+    d
+  )
 }
 
 nn_indices <- function(data, k, distance) {
@@ -286,13 +372,7 @@ nn_dists_cross <- function(query, reference, k, distance) {
     query_t <- metric_transform(query, distance, cov_data = reference)
     reference_t <- metric_transform(reference, distance, cov_data = reference)
     d <- RANN::nn2(reference_t, query_t, k = k)$nn.dists
-    if (distance == "cosine") {
-      # RANN returns Euclidean distances between unit vectors, sqrt(2 - 2*cos).
-      # Convert to cosine distance (1 - cos_sim = d^2 / 2) so magnitudes are
-      # correct for consumers such as NearMiss that average per-neighbor values.
-      return(d^2 / 2)
-    }
-    return(d)
+    return(metric_rescale_dists(d, distance))
   }
   dist_method <- switch(
     distance,

--- a/R/smote.R
+++ b/R/smote.R
@@ -16,11 +16,20 @@
 #'  to generate the new examples of the minority class.
 #' @param distance A character string specifying the distance metric used for
 #'  nearest neighbor calculations. One of `"euclidean"` (default), `"cosine"`,
-#'  `"mahalanobis"`, `"manhattan"`, or `"chebyshev"`. `"euclidean"`,
-#'  `"cosine"`, and `"mahalanobis"` use approximate nearest neighbors via
-#'  the RANN package and scale well to large datasets. `"manhattan"` and
+#'  `"mahalanobis"`, `"manhattan"`, `"chebyshev"`, `"squared_chord"`,
+#'  `"matusita"`, `"hellinger"`, or `"bhattacharyya"`. All except
+#'  `"manhattan"` and `"chebyshev"` use approximate nearest neighbors via the
+#'  RANN package and scale well to large datasets. `"manhattan"` and
 #'  `"chebyshev"` compute an exact O(n^2) distance matrix and may be slow for
 #'  large datasets.
+#'
+#'  `"squared_chord"`, `"matusita"`, `"hellinger"`, and `"bhattacharyya"` are
+#'  probability-divergence measures that treat each row as a distribution over
+#'  the predictors, so they require non-negative values. `"hellinger"` and
+#'  `"bhattacharyya"` further require each row to sum to 1. These metrics are
+#'  meaningful for compositional predictors such as proportions or counts
+#'  normalized per observation, and are generally not appropriate for
+#'  standardized predictors.
 #' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the

--- a/man/adasyn.Rd
+++ b/man/adasyn.Rd
@@ -25,11 +25,20 @@ half as many rows as the majority level. See
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/bsmote.Rd
+++ b/man/bsmote.Rd
@@ -35,11 +35,20 @@ See details.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/cnn.Rd
+++ b/man/cnn.Rd
@@ -14,11 +14,20 @@ numeric variables.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/enn.Rd
+++ b/man/enn.Rd
@@ -18,11 +18,20 @@ over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{times}{A positive integer for the maximum number of times ENN is
 applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat

--- a/man/instance_hardness.Rd
+++ b/man/instance_hardness.Rd
@@ -25,11 +25,20 @@ twice as many rows than the minority level. See
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/ncl.Rd
+++ b/man/ncl.Rd
@@ -18,11 +18,20 @@ over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{threshold_clean}{A numeric. Majority classes are only cleaned around
 minority class observations when their size is greater than

--- a/man/nearmiss.Rd
+++ b/man/nearmiss.Rd
@@ -25,11 +25,20 @@ twice as many rows than the minority level. See
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/oss.Rd
+++ b/man/oss.Rd
@@ -14,11 +14,20 @@ numeric variables.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/smogn.Rd
+++ b/man/smogn.Rd
@@ -36,11 +36,20 @@ generating synthetic examples in unsafe regions. Defaults to \code{0.02}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/smote.Rd
+++ b/man/smote.Rd
@@ -25,11 +25,20 @@ half as many rows as the majority level. See
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/step_adasyn.Rd
+++ b/man/step_adasyn.Rd
@@ -51,11 +51,20 @@ to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_bsmote.Rd
+++ b/man/step_bsmote.Rd
@@ -55,11 +55,20 @@ See details.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_cnn.Rd
+++ b/man/step_cnn.Rd
@@ -39,11 +39,20 @@ be populated (eventually) by the \code{...} selectors.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -46,11 +46,20 @@ over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{times}{A positive integer for the maximum number of times ENN is
 applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat

--- a/man/step_instance_hardness.Rd
+++ b/man/step_instance_hardness.Rd
@@ -52,11 +52,20 @@ to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_ncl.Rd
+++ b/man/step_ncl.Rd
@@ -45,11 +45,20 @@ over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{threshold_clean}{A numeric. Majority classes are only cleaned around
 minority class observations when their size is greater than

--- a/man/step_nearmiss.Rd
+++ b/man/step_nearmiss.Rd
@@ -52,11 +52,20 @@ to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_oss.Rd
+++ b/man/step_oss.Rd
@@ -39,11 +39,20 @@ be populated (eventually) by the \code{...} selectors.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_smogn.Rd
+++ b/man/step_smogn.Rd
@@ -56,11 +56,20 @@ generating synthetic examples in unsafe regions. Defaults to \code{0.02}.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_smote.Rd
+++ b/man/step_smote.Rd
@@ -51,11 +51,20 @@ to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_svmsmote.Rd
+++ b/man/step_svmsmote.Rd
@@ -51,11 +51,20 @@ to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_tomek.Rd
+++ b/man/step_tomek.Rd
@@ -39,11 +39,20 @@ be populated (eventually) by the \code{...} selectors.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/svmsmote.Rd
+++ b/man/svmsmote.Rd
@@ -25,11 +25,20 @@ half as many rows as the majority level. See
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/tomek.Rd
+++ b/man/tomek.Rd
@@ -14,11 +14,20 @@ numeric variables.}
 
 \item{distance}{A character string specifying the distance metric used for
 nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, or \code{"chebyshev"}. \code{"euclidean"},
-\code{"cosine"}, and \code{"mahalanobis"} use approximate nearest neighbors via
-the RANN package and scale well to large datasets. \code{"manhattan"} and
+\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
+\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
+\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
+RANN package and scale well to large datasets. \code{"manhattan"} and
 \code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.}
+large datasets.
+
+\code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
+probability-divergence measures that treat each row as a distribution over
+the predictors, so they require non-negative values. \code{"hellinger"} and
+\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
+meaningful for compositional predictors such as proportions or counts
+normalized per observation, and are generally not appropriate for
+standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/tests/testthat/_snaps/adasyn.md
+++ b/tests/testthat/_snaps/adasyn.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_adasyn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/adasyn_impl.md
+++ b/tests/testthat/_snaps/adasyn_impl.md
@@ -4,7 +4,7 @@
       adasyn(circle_example_num, var = "class", distance = "minkowski")
     Condition
       Error in `adasyn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 
 # adasyn() interfaces correctly
 

--- a/tests/testthat/_snaps/bsmote.md
+++ b/tests/testthat/_snaps/bsmote.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_bsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/bsmote_impl.md
+++ b/tests/testthat/_snaps/bsmote_impl.md
@@ -4,7 +4,7 @@
       bsmote(circle_example_num, var = "class", distance = "minkowski")
     Condition
       Error in `bsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 
 # bsmote() interfaces correctly
 

--- a/tests/testthat/_snaps/cnn.md
+++ b/tests/testthat/_snaps/cnn.md
@@ -53,7 +53,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_cnn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/cnn_impl.md
+++ b/tests/testthat/_snaps/cnn_impl.md
@@ -4,5 +4,5 @@
       cnn(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `cnn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -96,7 +96,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_enn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/instance_hardness.md
+++ b/tests/testthat/_snaps/instance_hardness.md
@@ -64,7 +64,7 @@
       class, distance = "L2")), new_data = NULL)
     Condition
       Error in `step_instance_hardness()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/instance_hardness_impl.md
+++ b/tests/testthat/_snaps/instance_hardness_impl.md
@@ -14,5 +14,5 @@
       instance_hardness(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `instance_hardness()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -8,3 +8,36 @@
       i 4 observations were found but 5 predictors are present.
       i Try a different `distance` metric or reduce the number of predictors.
 
+# sqrt-embedded metrics reject non-distribution predictors
+
+    Code
+      nn_indices(negative, 1, "matusita")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "matusita"` requires non-negative predictor values.
+      i Negative values were found in the columns used to compute distances.
+      i Each row is treated as a probability distribution by this metric.
+      i Try a different `distance` metric or rescale the predictors.
+
+---
+
+    Code
+      nn_indices(unnormalized, 1, "hellinger")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "hellinger"` requires each row to sum to 1.
+      i 3 rows do not sum to 1.
+      i Each row is treated as a probability distribution by this metric.
+      i Try `distance = "matusita"` or `distance = "squared_chord"`, which do not require this.
+
+---
+
+    Code
+      nn_indices(unnormalized, 1, "bhattacharyya")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "bhattacharyya"` requires each row to sum to 1.
+      i 3 rows do not sum to 1.
+      i Each row is treated as a probability distribution by this metric.
+      i Try `distance = "matusita"` or `distance = "squared_chord"`, which do not require this.
+

--- a/tests/testthat/_snaps/ncl.md
+++ b/tests/testthat/_snaps/ncl.md
@@ -64,7 +64,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_ncl()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/nearmiss.md
+++ b/tests/testthat/_snaps/nearmiss.md
@@ -63,7 +63,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_nearmiss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/nearmiss_impl.md
+++ b/tests/testthat/_snaps/nearmiss_impl.md
@@ -4,7 +4,7 @@
       nearmiss(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `nearmiss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 
 # bad args
 

--- a/tests/testthat/_snaps/oss.md
+++ b/tests/testthat/_snaps/oss.md
@@ -53,7 +53,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_oss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/oss_impl.md
+++ b/tests/testthat/_snaps/oss_impl.md
@@ -4,5 +4,5 @@
       oss(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `oss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 

--- a/tests/testthat/_snaps/smogn.md
+++ b/tests/testthat/_snaps/smogn.md
@@ -5,7 +5,7 @@
       new_data = NULL)
     Condition
       Error in `step_smogn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad data
 

--- a/tests/testthat/_snaps/smogn_impl.md
+++ b/tests/testthat/_snaps/smogn_impl.md
@@ -4,7 +4,7 @@
       smogn(circle_example[, c("x", "y")], var = "y", distance = "minkowski")
     Condition
       Error in `smogn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 
 # degenerate outcome errors during automatic relevance
 

--- a/tests/testthat/_snaps/smote.md
+++ b/tests/testthat/_snaps/smote.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_smote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/smote_impl.md
+++ b/tests/testthat/_snaps/smote_impl.md
@@ -4,7 +4,7 @@
       smote(circle_example[, c("x", "y", "class")], var = "class", distance = "minkowski")
     Condition
       Error in `smote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 
 # smote() interfaces correctly
 

--- a/tests/testthat/_snaps/svmsmote.md
+++ b/tests/testthat/_snaps/svmsmote.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_svmsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/svmsmote_impl.md
+++ b/tests/testthat/_snaps/svmsmote_impl.md
@@ -13,5 +13,5 @@
       svmsmote(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `svmsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 

--- a/tests/testthat/_snaps/tomek.md
+++ b/tests/testthat/_snaps/tomek.md
@@ -53,7 +53,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_tomek()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/tomek_impl.md
+++ b/tests/testthat/_snaps/tomek_impl.md
@@ -4,7 +4,7 @@
       tomek(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `tomek()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", or "chebyshev", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
 
 # tomek() interfaces correctly
 

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -56,6 +56,102 @@ test_that("nn_dists_cross() returns cosine-distance magnitudes 1 - cos_sim (#244
   expect_equal(d, expected)
 })
 
+# Rows on the probability simplex, chosen so no two pairwise distances tie.
+simplex_fixture <- function() {
+  rbind(
+    c(0.60, 0.30, 0.10),
+    c(0.50, 0.42, 0.08),
+    c(0.10, 0.21, 0.69),
+    c(0.22, 0.18, 0.60),
+    c(0.34, 0.33, 0.33)
+  )
+}
+
+# Direct formulas for the sqrt-embedded metrics, used to check that the RANN
+# search on square-rooted coordinates agrees with the definitions.
+divergence_matrix <- function(x, y, distance) {
+  f <- switch(
+    distance,
+    "squared_chord" = \(a, b) sum((sqrt(a) - sqrt(b))^2),
+    "matusita" = \(a, b) sqrt(sum((sqrt(a) - sqrt(b))^2)),
+    "hellinger" = \(a, b) 2 * sqrt(1 - sum(sqrt(a * b))),
+    "bhattacharyya" = \(a, b) -log(sum(sqrt(a * b)))
+  )
+  outer(
+    seq_len(nrow(x)),
+    seq_len(nrow(y)),
+    Vectorize(function(i, j) f(x[i, ], y[j, ]))
+  )
+}
+
+test_that("nn_indices() matches brute-force sqrt-embedded divergence neighbors", {
+  data <- simplex_fixture()
+  expect_nn <- function(distance) {
+    d <- divergence_matrix(data, data, distance)
+    expected <- t(apply(d, 1, \(x) order(x)[seq_len(3)]))
+    expect_equal(nn_indices(data, k = 2, distance), expected)
+  }
+
+  expect_nn("squared_chord")
+  expect_nn("matusita")
+  expect_nn("hellinger")
+  expect_nn("bhattacharyya")
+})
+
+test_that("nn_indices_cross() matches brute-force sqrt-embedded neighbors", {
+  data <- simplex_fixture()
+  query <- data[1:2, ]
+  reference <- data[3:5, ]
+  expect_nn <- function(distance) {
+    d <- divergence_matrix(query, reference, distance)
+    expected <- t(apply(d, 1, \(x) order(x)[seq_len(2)]))
+    expect_equal(nn_indices_cross(query, reference, k = 2, distance), expected)
+  }
+
+  expect_nn("squared_chord")
+  expect_nn("matusita")
+  expect_nn("hellinger")
+  expect_nn("bhattacharyya")
+})
+
+test_that("nn_dists_cross() returns true divergence magnitudes, not euclidean", {
+  data <- simplex_fixture()
+  query <- data[1:2, ]
+  reference <- data[3:5, ]
+  expect_dists <- function(distance) {
+    d <- divergence_matrix(query, reference, distance)
+    expected <- t(apply(d, 1, \(x) sort(x)[seq_len(2)]))
+    expect_equal(nn_dists_cross(query, reference, k = 2, distance), expected)
+  }
+
+  expect_dists("squared_chord")
+  expect_dists("matusita")
+  expect_dists("hellinger")
+  expect_dists("bhattacharyya")
+})
+
+test_that("bhattacharyya distance is infinite for disjoint support", {
+  query <- matrix(c(1, 0, 0, 0), ncol = 2, byrow = TRUE)
+  reference <- matrix(c(0, 1), ncol = 2)
+  expect_equal(
+    nn_dists_cross(query[1, , drop = FALSE], reference, 1, "bhattacharyya"),
+    matrix(Inf)
+  )
+})
+
+test_that("sqrt-embedded metrics reject non-distribution predictors", {
+  negative <- rbind(c(0.5, -0.5, 1), c(0.2, 0.3, 0.5))
+  expect_snapshot(error = TRUE, nn_indices(negative, 1, "matusita"))
+
+  unnormalized <- rbind(c(1, 2, 3), c(3, 2, 1), c(1, 1, 4))
+  expect_snapshot(error = TRUE, nn_indices(unnormalized, 1, "hellinger"))
+  expect_snapshot(error = TRUE, nn_indices(unnormalized, 1, "bhattacharyya"))
+
+  # squared_chord and matusita hold off the simplex, so they are allowed
+  expect_no_error(nn_indices(unnormalized, 1, "squared_chord"))
+  expect_no_error(nn_indices(unnormalized, 1, "matusita"))
+})
+
 test_that("mahalanobis whitening reproduces stats::mahalanobis distances (#237)", {
   set.seed(1)
   n <- 200

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -31,6 +31,30 @@ test_that("distance argument accepted by step_smote()", {
   )
 })
 
+test_that("sqrt-embedded distance metrics accepted by step_smote()", {
+  set.seed(1)
+  raw <- matrix(runif(60 * 3), ncol = 3)
+  props <- raw / rowSums(raw)
+  compositional <- data.frame(
+    x = props[, 1],
+    y = props[, 2],
+    z = props[, 3],
+    class = factor(rep(c("a", "b"), times = c(50, 10)))
+  )
+
+  bake_with <- function(distance) {
+    recipe(class ~ ., data = compositional) |>
+      step_smote(class, distance = distance) |>
+      prep() |>
+      bake(new_data = NULL)
+  }
+
+  expect_no_error(bake_with("squared_chord"))
+  expect_no_error(bake_with("matusita"))
+  expect_no_error(bake_with("hellinger"))
+  expect_no_error(bake_with("bhattacharyya"))
+})
+
 test_that("bad distance arg for step_smote()", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
Part of #234, which asked about adding philentropy as a backend to broaden the available `distance` metrics. This covers the subset that needs no new dependency: `squared_chord`, `matusita`, `hellinger`, and `bhattacharyya` are all exactly Euclidean distance on the elementwise square root of the data, up to a monotone transform of the resulting distance. That means they slot into the existing `metric_transform()` machinery and run on the fast RANN path, rather than the dense O(n^2) fallback that every philentropy metric would have required.

The metrics treat each row as a distribution over the predictors, so they reject negative values, and `hellinger` and `bhattacharyya` additionally require rows to sum to 1 (the fidelity identity they derive from only holds on the simplex). Those cases error rather than silently renormalizing the user's data.

The remaining metrics from the issue (Canberra, KL, Jensen-Shannon, and friends) have no such embedding and would genuinely need philentropy plus the slow path. That is left for a follow-up so it can be decided on its own merits.