### PR TITLE
Add philentropy divergence metrics to the distance argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     ggplot2,
     kernlab,
     modeldata,
+    philentropy,
     testthat (>= 3.0.0)
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
 
 * The `distance` argument of every step that performs nearest neighbor calculations gains four probability-divergence metrics: `"squared_chord"`, `"matusita"`, `"hellinger"`, and `"bhattacharyya"`. These treat each row as a distribution over the predictors and so require non-negative values, with `"hellinger"` and `"bhattacharyya"` further requiring each row to sum to 1. All four run on the fast approximate nearest neighbor path and scale to large data (#234).
 
+* The `distance` argument of every step that performs nearest neighbor calculations gains nine further probability-divergence metrics, provided by the philentropy package: `"canberra"`, `"soergel"`, `"lorentzian"`, `"jeffreys"`, `"topsoe"`, `"jensen-shannon"`, `"jensen_difference"`, `"taneja"`, and `"kumar-johnson"`. philentropy is an optional dependency, and since these metrics compute an exact all-pairs distance matrix they are best suited to smaller datasets (#234).
+
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_smotenc()` now document the minimum number of observations needed to perform the algorithm (#104).
 
 * `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).

--- a/R/misc.R
+++ b/R/misc.R
@@ -199,7 +199,8 @@ check_distance_arg <- function(distance, call = caller_env()) {
       "mahalanobis",
       "manhattan",
       "chebyshev",
-      sqrt_embedded_metrics()
+      sqrt_embedded_metrics(),
+      philentropy_metrics()
     ),
     error_call = call
   )
@@ -256,6 +257,53 @@ metric_is_transformable <- function(distance) {
     c("euclidean", "cosine", "mahalanobis", sqrt_embedded_metrics())
 }
 
+# Divergence measures computed by philentropy. Deliberately a curated allowlist
+# rather than `philentropy::getDistMethods()`:
+#
+# * That list mixes distances with similarity measures (intersection, cosine,
+#   fidelity, inner_product, harmonic_mean, hassebrook, kulczynski_s, ruzicka),
+#   where a *larger* value means a *closer* pair. The neighbor search sorts
+#   ascending, so those would silently return the farthest neighbors.
+# * philentropy computes one triangle of the distance matrix and mirrors it, so
+#   asymmetric measures such as kullback-leibler come back symmetrized rather
+#   than as the requested divergence. Only symmetric measures are listed here.
+# * Names already handled by a faster path (euclidean, manhattan, chebyshev,
+#   cosine, and the sqrt-embedded metrics) are excluded so each metric has
+#   exactly one spelling and one backend.
+philentropy_metrics <- function() {
+  c(
+    "canberra",
+    "soergel",
+    "lorentzian",
+    "jeffreys",
+    "topsoe",
+    "jensen-shannon",
+    "jensen_difference",
+    "taneja",
+    "kumar-johnson"
+  )
+}
+
+# philentropy metrics that divide by, or take the log of, individual values, so a
+# zero anywhere makes the true distance infinite. philentropy returns a finite
+# but meaningless number in that case rather than `Inf`, so the input has to be
+# checked up front; there is no non-finite result to detect afterwards.
+philentropy_positive_metrics <- function() {
+  c("jeffreys", "taneja", "kumar-johnson")
+}
+
+# Which engine computes distances for `distance`. "rann" is the fast approximate
+# path, "dist" and "philentropy" both build a dense O(n^2) matrix.
+metric_backend <- function(distance) {
+  if (metric_is_transformable(distance)) {
+    "rann"
+  } else if (distance %in% philentropy_metrics()) {
+    "philentropy"
+  } else {
+    "dist"
+  }
+}
+
 check_metric_nonnegative <- function(data, distance, call = caller_env()) {
   if (any(data < 0)) {
     cli::cli_abort(
@@ -264,6 +312,24 @@ check_metric_nonnegative <- function(data, distance, call = caller_env()) {
         i = "Negative values were found in the columns used to compute distances.",
         i = "Each row is treated as a probability distribution by this metric.",
         i = "Try a different {.arg distance} metric or rescale the predictors."
+      ),
+      call = call
+    )
+  }
+  invisible()
+}
+
+check_metric_positive <- function(data, distance, call = caller_env()) {
+  if (any(data <= 0)) {
+    cli::cli_abort(
+      c(
+        "{.code distance = \"{distance}\"} requires strictly positive predictor values.",
+        i = "Zero or negative values were found in the columns used to compute \\
+             distances.",
+        i = "This metric divides by individual values, so a zero makes the \\
+             distance infinite.",
+        i = "Try {.code distance = \"jensen-shannon\"} or \\
+             {.code distance = \"canberra\"}, which allow zeros."
       ),
       call = call
     )
@@ -353,17 +419,57 @@ metric_rescale_dists <- function(d, distance) {
   )
 }
 
-nn_indices <- function(data, k, distance) {
-  if (metric_is_transformable(distance)) {
-    data <- metric_transform(data, distance)
-    return(RANN::nn2(data, k = k + 1, searchtype = "priority")$nn.idx)
+# Dense all-pairs distance matrix for the metrics that have no fast path. Both
+# backends here are O(n^2) in time and memory.
+dense_dist_matrix <- function(data, distance, call = caller_env()) {
+  if (metric_backend(distance) == "philentropy") {
+    rlang::check_installed(
+      "philentropy",
+      sprintf("for `distance = \"%s\"`.", distance),
+      call = call
+    )
+    check_metric_nonnegative(data, distance, call = call)
+    if (distance %in% philentropy_positive_metrics()) {
+      check_metric_positive(data, distance, call = call)
+    }
+    # `mute.message` silences some but not all of philentropy's chatter, so the
+    # remaining messages are suppressed here to keep step output clean.
+    res <- suppressMessages(philentropy::distance(
+      as.matrix(data),
+      method = distance,
+      test.na = FALSE,
+      mute.message = TRUE
+    ))
+    # With exactly two rows philentropy returns a bare scalar rather than a
+    # 2x2 matrix, so the callers' `apply()` over rows would fail.
+    if (!is.matrix(res)) {
+      res <- rbind(c(0, res), c(res, 0))
+    }
+    return(unname(res))
   }
   dist_method <- switch(
     distance,
     "manhattan" = "manhattan",
     "chebyshev" = "maximum"
   )
-  dist_mat <- as.matrix(stats::dist(data, method = dist_method))
+  as.matrix(stats::dist(data, method = dist_method))
+}
+
+# Dense query-by-reference distance block for the metrics with no fast path.
+# Neither backend computes a rectangular block directly, so both sets are stacked
+# and the query-vs-reference corner is cut out of the full matrix.
+dense_dist_cross <- function(query, reference, distance, call = caller_env()) {
+  d_full <- dense_dist_matrix(rbind(query, reference), distance, call = call)
+  nq <- nrow(query)
+  d_full[seq_len(nq), nq + seq_len(nrow(reference)), drop = FALSE]
+}
+
+nn_indices <- function(data, k, distance) {
+  if (metric_is_transformable(distance)) {
+    data <- metric_transform(data, distance)
+    return(RANN::nn2(data, k = k + 1, searchtype = "priority")$nn.idx)
+  }
+  dist_mat <- dense_dist_matrix(data, distance)
   t(apply(dist_mat, 1, \(x) order(x)[seq_len(k + 1)]))
 }
 
@@ -374,17 +480,9 @@ nn_dists_cross <- function(query, reference, k, distance) {
     d <- RANN::nn2(reference_t, query_t, k = k)$nn.dists
     return(metric_rescale_dists(d, distance))
   }
-  dist_method <- switch(
-    distance,
-    "manhattan" = "manhattan",
-    "chebyshev" = "maximum"
-  )
-  combined <- rbind(query, reference)
-  d_full <- as.matrix(stats::dist(combined, method = dist_method))
-  nq <- nrow(query)
-  d_cross <- d_full[seq_len(nq), nq + seq_len(nrow(reference)), drop = FALSE]
+  d_cross <- dense_dist_cross(query, reference, distance)
   res <- apply(d_cross, 1, \(x) sort(x)[seq_len(k)])
-  matrix(res, nrow = nq, ncol = k, byrow = TRUE)
+  matrix(res, nrow = nrow(query), ncol = k, byrow = TRUE)
 }
 
 nn_indices_cross <- function(query, reference, k, distance) {
@@ -393,17 +491,9 @@ nn_indices_cross <- function(query, reference, k, distance) {
     reference_t <- metric_transform(reference, distance, cov_data = reference)
     return(RANN::nn2(reference_t, query_t, k = k)$nn.idx)
   }
-  dist_method <- switch(
-    distance,
-    "manhattan" = "manhattan",
-    "chebyshev" = "maximum"
-  )
-  combined <- rbind(query, reference)
-  d_full <- as.matrix(stats::dist(combined, method = dist_method))
-  nq <- nrow(query)
-  d_cross <- d_full[seq_len(nq), nq + seq_len(nrow(reference)), drop = FALSE]
+  d_cross <- dense_dist_cross(query, reference, distance)
   res <- apply(d_cross, 1, \(x) order(x)[seq_len(k)])
-  matrix(res, nrow = nq, ncol = k, byrow = TRUE)
+  matrix(res, nrow = nrow(query), ncol = k, byrow = TRUE)
 }
 
 # Shared condensation scan for CNN and one-sided selection. Walks `candidates`

--- a/R/smote.R
+++ b/R/smote.R
@@ -15,21 +15,32 @@
 #' @param neighbors An integer. Number of nearest neighbor that are used
 #'  to generate the new examples of the minority class.
 #' @param distance A character string specifying the distance metric used for
-#'  nearest neighbor calculations. One of `"euclidean"` (default), `"cosine"`,
-#'  `"mahalanobis"`, `"manhattan"`, `"chebyshev"`, `"squared_chord"`,
-#'  `"matusita"`, `"hellinger"`, or `"bhattacharyya"`. All except
-#'  `"manhattan"` and `"chebyshev"` use approximate nearest neighbors via the
-#'  RANN package and scale well to large datasets. `"manhattan"` and
-#'  `"chebyshev"` compute an exact O(n^2) distance matrix and may be slow for
-#'  large datasets.
+#'  nearest neighbor calculations, defaulting to `"euclidean"`. The available
+#'  metrics fall into three groups.
+#'
+#'  `"euclidean"`, `"cosine"`, and `"mahalanobis"` use approximate nearest
+#'  neighbors via the RANN package and scale well to large datasets.
 #'
 #'  `"squared_chord"`, `"matusita"`, `"hellinger"`, and `"bhattacharyya"` are
 #'  probability-divergence measures that treat each row as a distribution over
 #'  the predictors, so they require non-negative values. `"hellinger"` and
-#'  `"bhattacharyya"` further require each row to sum to 1. These metrics are
-#'  meaningful for compositional predictors such as proportions or counts
-#'  normalized per observation, and are generally not appropriate for
-#'  standardized predictors.
+#'  `"bhattacharyya"` further require each row to sum to 1. All four also use
+#'  the RANN package and scale well to large datasets.
+#'
+#'  `"manhattan"`, `"chebyshev"`, `"canberra"`, `"soergel"`, `"lorentzian"`,
+#'  `"jeffreys"`, `"topsoe"`, `"jensen-shannon"`, `"jensen_difference"`,
+#'  `"taneja"`, and `"kumar-johnson"` compute an exact all-pairs distance
+#'  matrix. This takes time and memory proportional to the square of the number
+#'  of observations in a class, so these are best suited to smaller datasets.
+#'  Everything from `"canberra"` onwards is a probability divergence requiring
+#'  non-negative values, is provided by the philentropy package (which must be
+#'  installed separately), and in the case of `"jeffreys"`, `"taneja"`, and
+#'  `"kumar-johnson"` requires strictly positive values, since those divide by
+#'  individual predictor values.
+#'
+#'  The probability divergences are meaningful for compositional predictors such
+#'  as proportions or counts normalized per observation, and are generally not
+#'  appropriate for standardized predictors.
 #' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the

--- a/man/adasyn.Rd
+++ b/man/adasyn.Rd
@@ -24,21 +24,32 @@ half as many rows as the majority level. See
 \code{vignette("ratio", package = "themis")} for more details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/bsmote.Rd
+++ b/man/bsmote.Rd
@@ -34,21 +34,32 @@ half as many rows as the majority level. See
 See details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/cnn.Rd
+++ b/man/cnn.Rd
@@ -13,21 +13,32 @@ numeric variables.}
 \item{var}{Character, name of variable containing factor variable.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/enn.Rd
+++ b/man/enn.Rd
@@ -17,21 +17,32 @@ decide whether an observation is removed. Defaults to \code{3}, unlike the
 over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{times}{A positive integer for the maximum number of times ENN is
 applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat

--- a/man/instance_hardness.Rd
+++ b/man/instance_hardness.Rd
@@ -24,21 +24,32 @@ twice as many rows than the minority level. See
 \code{vignette("ratio", package = "themis")} for more details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/ncl.Rd
+++ b/man/ncl.Rd
@@ -17,21 +17,32 @@ decide whether an observation is removed. Defaults to \code{3}, unlike the
 over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{threshold_clean}{A numeric. Majority classes are only cleaned around
 minority class observations when their size is greater than

--- a/man/nearmiss.Rd
+++ b/man/nearmiss.Rd
@@ -24,21 +24,32 @@ twice as many rows than the minority level. See
 \code{vignette("ratio", package = "themis")} for more details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/oss.Rd
+++ b/man/oss.Rd
@@ -13,21 +13,32 @@ numeric variables.}
 \item{var}{Character, name of variable containing factor variable.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/smogn.Rd
+++ b/man/smogn.Rd
@@ -35,21 +35,32 @@ to generate the new examples of the rare values.}
 generating synthetic examples in unsafe regions. Defaults to \code{0.02}.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/smote.Rd
+++ b/man/smote.Rd
@@ -24,21 +24,32 @@ half as many rows as the majority level. See
 \code{vignette("ratio", package = "themis")} for more details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/step_adasyn.Rd
+++ b/man/step_adasyn.Rd
@@ -50,21 +50,32 @@ half as many rows as the majority level. See
 to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_bsmote.Rd
+++ b/man/step_bsmote.Rd
@@ -54,21 +54,32 @@ to generate the new examples of the minority class.}
 See details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_cnn.Rd
+++ b/man/step_cnn.Rd
@@ -38,21 +38,32 @@ been estimated.}
 be populated (eventually) by the \code{...} selectors.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -45,21 +45,32 @@ decide whether an observation is removed. Defaults to \code{3}, unlike the
 over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{times}{A positive integer for the maximum number of times ENN is
 applied. Defaults to \code{1} for a single pass. Values greater than \code{1} repeat

--- a/man/step_instance_hardness.Rd
+++ b/man/step_instance_hardness.Rd
@@ -51,21 +51,32 @@ twice as many rows than the minority level. See
 to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_ncl.Rd
+++ b/man/step_ncl.Rd
@@ -44,21 +44,32 @@ decide whether an observation is removed. Defaults to \code{3}, unlike the
 over-sampling steps which default to \code{5}.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{threshold_clean}{A numeric. Majority classes are only cleaned around
 minority class observations when their size is greater than

--- a/man/step_nearmiss.Rd
+++ b/man/step_nearmiss.Rd
@@ -51,21 +51,32 @@ twice as many rows than the minority level. See
 to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_oss.Rd
+++ b/man/step_oss.Rd
@@ -38,21 +38,32 @@ been estimated.}
 be populated (eventually) by the \code{...} selectors.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/step_smogn.Rd
+++ b/man/step_smogn.Rd
@@ -55,21 +55,32 @@ to generate the new examples of the rare values.}
 generating synthetic examples in unsafe regions. Defaults to \code{0.02}.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_smote.Rd
+++ b/man/step_smote.Rd
@@ -50,21 +50,32 @@ half as many rows as the majority level. See
 to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_svmsmote.Rd
+++ b/man/step_svmsmote.Rd
@@ -50,21 +50,32 @@ half as many rows as the majority level. See
 to generate the new examples of the minority class.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,

--- a/man/step_tomek.Rd
+++ b/man/step_tomek.Rd
@@ -38,21 +38,32 @@ been estimated.}
 be populated (eventually) by the \code{...} selectors.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some

--- a/man/svmsmote.Rd
+++ b/man/svmsmote.Rd
@@ -24,21 +24,32 @@ half as many rows as the majority level. See
 \code{vignette("ratio", package = "themis")} for more details.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/man/tomek.Rd
+++ b/man/tomek.Rd
@@ -13,21 +13,32 @@ numeric variables.}
 \item{var}{Character, name of variable containing factor variable.}
 
 \item{distance}{A character string specifying the distance metric used for
-nearest neighbor calculations. One of \code{"euclidean"} (default), \code{"cosine"},
-\code{"mahalanobis"}, \code{"manhattan"}, \code{"chebyshev"}, \code{"squared_chord"},
-\code{"matusita"}, \code{"hellinger"}, or \code{"bhattacharyya"}. All except
-\code{"manhattan"} and \code{"chebyshev"} use approximate nearest neighbors via the
-RANN package and scale well to large datasets. \code{"manhattan"} and
-\code{"chebyshev"} compute an exact O(n^2) distance matrix and may be slow for
-large datasets.
+nearest neighbor calculations, defaulting to \code{"euclidean"}. The available
+metrics fall into three groups.
+
+\code{"euclidean"}, \code{"cosine"}, and \code{"mahalanobis"} use approximate nearest
+neighbors via the RANN package and scale well to large datasets.
 
 \code{"squared_chord"}, \code{"matusita"}, \code{"hellinger"}, and \code{"bhattacharyya"} are
 probability-divergence measures that treat each row as a distribution over
 the predictors, so they require non-negative values. \code{"hellinger"} and
-\code{"bhattacharyya"} further require each row to sum to 1. These metrics are
-meaningful for compositional predictors such as proportions or counts
-normalized per observation, and are generally not appropriate for
-standardized predictors.}
+\code{"bhattacharyya"} further require each row to sum to 1. All four also use
+the RANN package and scale well to large datasets.
+
+\code{"manhattan"}, \code{"chebyshev"}, \code{"canberra"}, \code{"soergel"}, \code{"lorentzian"},
+\code{"jeffreys"}, \code{"topsoe"}, \code{"jensen-shannon"}, \code{"jensen_difference"},
+\code{"taneja"}, and \code{"kumar-johnson"} compute an exact all-pairs distance
+matrix. This takes time and memory proportional to the square of the number
+of observations in a class, so these are best suited to smaller datasets.
+Everything from \code{"canberra"} onwards is a probability divergence requiring
+non-negative values, is provided by the philentropy package (which must be
+installed separately), and in the case of \code{"jeffreys"}, \code{"taneja"}, and
+\code{"kumar-johnson"} requires strictly positive values, since those divide by
+individual predictor values.
+
+The probability divergences are meaningful for compositional predictors such
+as proportions or counts normalized per observation, and are generally not
+appropriate for standardized predictors.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.

--- a/tests/testthat/_snaps/adasyn.md
+++ b/tests/testthat/_snaps/adasyn.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_adasyn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/adasyn_impl.md
+++ b/tests/testthat/_snaps/adasyn_impl.md
@@ -4,7 +4,7 @@
       adasyn(circle_example_num, var = "class", distance = "minkowski")
     Condition
       Error in `adasyn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 
 # adasyn() interfaces correctly
 

--- a/tests/testthat/_snaps/bsmote.md
+++ b/tests/testthat/_snaps/bsmote.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_bsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/bsmote_impl.md
+++ b/tests/testthat/_snaps/bsmote_impl.md
@@ -4,7 +4,7 @@
       bsmote(circle_example_num, var = "class", distance = "minkowski")
     Condition
       Error in `bsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 
 # bsmote() interfaces correctly
 

--- a/tests/testthat/_snaps/cnn.md
+++ b/tests/testthat/_snaps/cnn.md
@@ -53,7 +53,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_cnn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/cnn_impl.md
+++ b/tests/testthat/_snaps/cnn_impl.md
@@ -4,5 +4,5 @@
       cnn(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `cnn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -96,7 +96,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_enn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/instance_hardness.md
+++ b/tests/testthat/_snaps/instance_hardness.md
@@ -64,7 +64,7 @@
       class, distance = "L2")), new_data = NULL)
     Condition
       Error in `step_instance_hardness()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/instance_hardness_impl.md
+++ b/tests/testthat/_snaps/instance_hardness_impl.md
@@ -14,5 +14,5 @@
       instance_hardness(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `instance_hardness()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -41,3 +41,63 @@
       i Each row is treated as a probability distribution by this metric.
       i Try `distance = "matusita"` or `distance = "squared_chord"`, which do not require this.
 
+# philentropy metrics exclude similarity measures and asymmetric ones
+
+    Code
+      check_distance_arg("intersection")
+    Condition
+      Error:
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "intersection".
+
+---
+
+    Code
+      check_distance_arg("kullback-leibler")
+    Condition
+      Error:
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "kullback-leibler".
+
+# philentropy metrics that divide by values reject zeros
+
+    Code
+      nn_indices(with_zero, 1, "jeffreys")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "jeffreys"` requires strictly positive predictor values.
+      i Zero or negative values were found in the columns used to compute distances.
+      i This metric divides by individual values, so a zero makes the distance infinite.
+      i Try `distance = "jensen-shannon"` or `distance = "canberra"`, which allow zeros.
+
+---
+
+    Code
+      nn_indices(with_zero, 1, "taneja")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "taneja"` requires strictly positive predictor values.
+      i Zero or negative values were found in the columns used to compute distances.
+      i This metric divides by individual values, so a zero makes the distance infinite.
+      i Try `distance = "jensen-shannon"` or `distance = "canberra"`, which allow zeros.
+
+---
+
+    Code
+      nn_indices(with_zero, 1, "kumar-johnson")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "kumar-johnson"` requires strictly positive predictor values.
+      i Zero or negative values were found in the columns used to compute distances.
+      i This metric divides by individual values, so a zero makes the distance infinite.
+      i Try `distance = "jensen-shannon"` or `distance = "canberra"`, which allow zeros.
+
+# philentropy metrics reject negative predictors
+
+    Code
+      nn_indices(negative, 1, "canberra")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "canberra"` requires non-negative predictor values.
+      i Negative values were found in the columns used to compute distances.
+      i Each row is treated as a probability distribution by this metric.
+      i Try a different `distance` metric or rescale the predictors.
+

--- a/tests/testthat/_snaps/ncl.md
+++ b/tests/testthat/_snaps/ncl.md
@@ -64,7 +64,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_ncl()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/nearmiss.md
+++ b/tests/testthat/_snaps/nearmiss.md
@@ -63,7 +63,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_nearmiss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/nearmiss_impl.md
+++ b/tests/testthat/_snaps/nearmiss_impl.md
@@ -4,7 +4,7 @@
       nearmiss(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `nearmiss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 
 # bad args
 

--- a/tests/testthat/_snaps/oss.md
+++ b/tests/testthat/_snaps/oss.md
@@ -53,7 +53,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_oss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/oss_impl.md
+++ b/tests/testthat/_snaps/oss_impl.md
@@ -4,5 +4,5 @@
       oss(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `oss()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 

--- a/tests/testthat/_snaps/smogn.md
+++ b/tests/testthat/_snaps/smogn.md
@@ -5,7 +5,7 @@
       new_data = NULL)
     Condition
       Error in `step_smogn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad data
 

--- a/tests/testthat/_snaps/smogn_impl.md
+++ b/tests/testthat/_snaps/smogn_impl.md
@@ -4,7 +4,7 @@
       smogn(circle_example[, c("x", "y")], var = "y", distance = "minkowski")
     Condition
       Error in `smogn()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 
 # degenerate outcome errors during automatic relevance
 

--- a/tests/testthat/_snaps/smote.md
+++ b/tests/testthat/_snaps/smote.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_smote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/smote_impl.md
+++ b/tests/testthat/_snaps/smote_impl.md
@@ -4,7 +4,7 @@
       smote(circle_example[, c("x", "y", "class")], var = "class", distance = "minkowski")
     Condition
       Error in `smote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 
 # smote() interfaces correctly
 

--- a/tests/testthat/_snaps/svmsmote.md
+++ b/tests/testthat/_snaps/svmsmote.md
@@ -5,7 +5,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_svmsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # errors if there isn't enough data
 

--- a/tests/testthat/_snaps/svmsmote_impl.md
+++ b/tests/testthat/_snaps/svmsmote_impl.md
@@ -13,5 +13,5 @@
       svmsmote(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `svmsmote()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 

--- a/tests/testthat/_snaps/tomek.md
+++ b/tests/testthat/_snaps/tomek.md
@@ -53,7 +53,7 @@
       distance = "L2")), new_data = NULL)
     Condition
       Error in `step_tomek()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "L2".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
 # bad args
 

--- a/tests/testthat/_snaps/tomek_impl.md
+++ b/tests/testthat/_snaps/tomek_impl.md
@@ -4,7 +4,7 @@
       tomek(circle_numeric, var = "class", distance = "minkowski")
     Condition
       Error in `tomek()`:
-      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", or "bhattacharyya", not "minkowski".
+      ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "minkowski".
 
 # tomek() interfaces correctly
 

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -152,6 +152,126 @@ test_that("sqrt-embedded metrics reject non-distribution predictors", {
   expect_no_error(nn_indices(unnormalized, 1, "matusita"))
 })
 
+test_that("metric_backend() routes each metric to one engine", {
+  expect_equal(metric_backend("euclidean"), "rann")
+  expect_equal(metric_backend("mahalanobis"), "rann")
+  expect_equal(metric_backend("hellinger"), "rann")
+  expect_equal(metric_backend("manhattan"), "dist")
+  expect_equal(metric_backend("chebyshev"), "dist")
+  expect_equal(metric_backend("canberra"), "philentropy")
+  expect_equal(metric_backend("jensen-shannon"), "philentropy")
+})
+
+test_that("philentropy metrics exclude similarity measures and asymmetric ones", {
+  # Similarity measures rank closer pairs *higher*, so the ascending neighbor
+  # sort would return the farthest rows. philentropy also mirrors one triangle of
+  # the matrix, which silently symmetrizes asymmetric measures like KL.
+  similarities <- c(
+    "intersection",
+    "cosine",
+    "fidelity",
+    "inner_product",
+    "harmonic_mean",
+    "hassebrook",
+    "kulczynski_s",
+    "ruzicka"
+  )
+  expect_equal(intersect(philentropy_metrics(), similarities), character(0))
+  expect_equal(
+    intersect(philentropy_metrics(), "kullback-leibler"),
+    character(0)
+  )
+
+  expect_snapshot(error = TRUE, check_distance_arg("intersection"))
+  expect_snapshot(error = TRUE, check_distance_arg("kullback-leibler"))
+})
+
+test_that("nn_indices() matches philentropy distances for divergence metrics", {
+  skip_if_not_installed("philentropy")
+  data <- simplex_fixture()
+
+  expect_nn <- function(distance) {
+    d <- suppressMessages(philentropy::distance(
+      data,
+      method = distance,
+      test.na = FALSE,
+      mute.message = TRUE
+    ))
+    expected <- t(apply(unname(d), 1, \(x) order(x)[seq_len(3)]))
+    expect_equal(nn_indices(data, k = 2, distance), expected)
+  }
+
+  expect_nn("canberra")
+  expect_nn("soergel")
+  expect_nn("lorentzian")
+  expect_nn("jeffreys")
+  expect_nn("topsoe")
+  expect_nn("jensen-shannon")
+  expect_nn("jensen_difference")
+  expect_nn("taneja")
+  expect_nn("kumar-johnson")
+})
+
+test_that("nn_dists_cross() returns philentropy magnitudes for divergence metrics", {
+  skip_if_not_installed("philentropy")
+  data <- simplex_fixture()
+  query <- data[1:2, ]
+  reference <- data[3:5, ]
+
+  expect_dists <- function(distance) {
+    d <- outer(
+      seq_len(nrow(query)),
+      seq_len(nrow(reference)),
+      Vectorize(function(i, j) {
+        suppressMessages(philentropy::distance(
+          rbind(query[i, ], reference[j, ]),
+          method = distance,
+          test.na = FALSE,
+          mute.message = TRUE
+        ))
+      })
+    )
+    expected <- t(apply(d, 1, \(x) sort(x)[seq_len(2)]))
+    expect_equal(nn_dists_cross(query, reference, k = 2, distance), expected)
+  }
+
+  expect_dists("canberra")
+  expect_dists("jensen-shannon")
+  expect_dists("taneja")
+})
+
+test_that("dense_dist_matrix() handles philentropy's scalar return for 2 rows", {
+  skip_if_not_installed("philentropy")
+  data <- simplex_fixture()[1:2, ]
+  d <- dense_dist_matrix(data, "canberra")
+
+  expect_equal(dim(d), c(2L, 2L))
+  expect_equal(diag(d), c(0, 0))
+  expect_equal(d[1, 2], d[2, 1])
+  expect_equal(nn_indices(data, k = 1, "canberra"), rbind(c(1L, 2L), c(2L, 1L)))
+})
+
+test_that("philentropy metrics that divide by values reject zeros", {
+  skip_if_not_installed("philentropy")
+  # philentropy returns a finite but meaningless number here rather than Inf,
+  # so the zero has to be caught before the distance is computed.
+  with_zero <- rbind(c(0.5, 0.5, 0.0), c(0.2, 0.3, 0.5), c(0.4, 0.4, 0.2))
+  expect_snapshot(error = TRUE, nn_indices(with_zero, 1, "jeffreys"))
+  expect_snapshot(error = TRUE, nn_indices(with_zero, 1, "taneja"))
+  expect_snapshot(error = TRUE, nn_indices(with_zero, 1, "kumar-johnson"))
+
+  # zero-safe divergences accept the same data
+  expect_no_error(nn_indices(with_zero, 1, "jensen-shannon"))
+  expect_no_error(nn_indices(with_zero, 1, "canberra"))
+  expect_no_error(nn_indices(with_zero, 1, "topsoe"))
+})
+
+test_that("philentropy metrics reject negative predictors", {
+  skip_if_not_installed("philentropy")
+  negative <- rbind(c(0.5, -0.5, 1), c(0.2, 0.3, 0.5), c(0.4, 0.4, 0.2))
+  expect_snapshot(error = TRUE, nn_indices(negative, 1, "canberra"))
+})
+
 test_that("mahalanobis whitening reproduces stats::mahalanobis distances (#237)", {
   set.seed(1)
   n <- 200

--- a/tests/testthat/test-smote.R
+++ b/tests/testthat/test-smote.R
@@ -55,6 +55,30 @@ test_that("sqrt-embedded distance metrics accepted by step_smote()", {
   expect_no_error(bake_with("bhattacharyya"))
 })
 
+test_that("philentropy distance metrics accepted by step_smote()", {
+  skip_if_not_installed("philentropy")
+  set.seed(1)
+  raw <- matrix(runif(60 * 3), ncol = 3)
+  props <- raw / rowSums(raw)
+  compositional <- data.frame(
+    x = props[, 1],
+    y = props[, 2],
+    z = props[, 3],
+    class = factor(rep(c("a", "b"), times = c(50, 10)))
+  )
+
+  bake_with <- function(distance) {
+    recipe(class ~ ., data = compositional) |>
+      step_smote(class, distance = distance) |>
+      prep() |>
+      bake(new_data = NULL)
+  }
+
+  expect_no_error(bake_with("canberra"))
+  expect_no_error(bake_with("jensen-shannon"))
+  expect_no_error(bake_with("kumar-johnson"))
+})
+
 test_that("bad distance arg for step_smote()", {
   expect_snapshot(
     error = TRUE,


### PR DESCRIPTION
Completes #234 by adding the divergence measures that have no Euclidean embedding, and so genuinely need philentropy and the dense O(n^2) path: `canberra`, `soergel`, `lorentzian`, `jeffreys`, `topsoe`, `jensen-shannon`, `jensen_difference`, `taneja`, and `kumar-johnson`. philentropy is an optional dependency, gated with `check_installed()`, since these metrics don't scale and shouldn't cost anything for the default `"euclidean"`.

The metric list is a curated allowlist rather than everything `getDistMethods()` offers, for two reasons worth knowing about. philentropy mixes distances with similarity measures where a larger value means a *closer* pair, and the neighbor search sorts ascending, so passing those through would have silently returned the farthest neighbors. It also computes one triangle of the distance matrix and mirrors it, which means asymmetric measures like `kullback-leibler` come back symmetrized rather than as the requested divergence: manual `KL(2||1)` is 0.128 where philentropy reports `KL(1||2)` = 0.134. Both classes are excluded, and the exclusions are covered by tests.

Separately, `jeffreys`, `taneja`, and `kumar-johnson` divide by individual predictor values, so a zero makes the true distance infinite. philentropy returns a finite but meaningless number instead of `Inf`, so these validate their input up front rather than checking for a non-finite result afterwards. All nine metrics are tested against philentropy's own output, and each was verified against its textbook definition while building this.