### PR TITLE
Error informatively on a singular mahalanobis covariance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@
 
 * The `distance` argument of every step that performs nearest neighbor calculations gains nine further probability-divergence metrics, provided by the philentropy package: `"canberra"`, `"soergel"`, `"lorentzian"`, `"jeffreys"`, `"topsoe"`, `"jensen-shannon"`, `"jensen_difference"`, `"taneja"`, and `"kumar-johnson"`. philentropy is an optional dependency, and since these metrics compute an exact all-pairs distance matrix they are best suited to smaller datasets (#234).
 
+* `distance = "mahalanobis"` now fails with an informative error when the predictors have a singular covariance matrix, instead of a low-level message from `chol()` or silently returning distances computed from a numerically unusable inverse. This covers collinear and constant predictors as well as duplicated rows (#246).
+
 * `step_adasyn()`, `step_bsmote()`, `step_nearmiss()`, `step_smote()`, and `step_smotenc()` now document the minimum number of observations needed to perform the algorithm (#104).
 
 * `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).

--- a/R/misc.R
+++ b/R/misc.R
@@ -392,10 +392,44 @@ metric_transform <- function(
       )
     }
     S <- stats::cov(cov_data)
-    return(data %*% solve(chol(S)))
+    return(data %*% solve(chol_cov(S, call = call)))
   }
   # euclidean: no transform needed
   data
+}
+
+# Cholesky factor of a covariance matrix, replacing the raw "the leading minor
+# of order k is not positive definite" error from `chol()` with a message that
+# points at the `distance` argument. A covariance matrix is singular when
+# predictors are collinear (including constant columns) or when duplicate rows
+# leave fewer distinct observations than predictors.
+#
+# Exactly collinear predictors do not always trip `chol()`: rounding can leave
+# the offending pivot a tiny positive number instead of zero, in which case
+# `chol()` succeeds and `solve()` returns an inverse of astronomical magnitude,
+# silently poisoning every distance. A rank check on the covariance catches those
+# cases before the factorization, using the same relative tolerance as `lm()`.
+chol_cov <- function(S, call = caller_env()) {
+  singular <- function(cnd = NULL) {
+    cli::cli_abort(
+      c(
+        "{.code distance = \"mahalanobis\"} requires an invertible covariance
+         matrix, but the covariance of the predictors is singular.",
+        i = "This happens when predictors are collinear or constant, or when
+             duplicated rows leave too few distinct observations.",
+        i = "Try a different {.arg distance} metric or remove the redundant
+             predictors."
+      ),
+      call = call,
+      parent = cnd
+    )
+  }
+
+  if (qr(S)$rank < ncol(S)) {
+    singular()
+  }
+
+  rlang::try_fetch(chol(S), error = function(cnd) singular(cnd))
 }
 
 # Convert Euclidean distances computed on `metric_transform()`ed coordinates into

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -224,8 +224,9 @@ smogn_relevance <- function(y, relevance = NULL, call = caller_env()) {
 # data (cosine, mahalanobis) or using the appropriate `stats::dist` method.
 smogn_distmat <- function(data, distance) {
   if (metric_is_transformable(distance)) {
-    # `check_singular = FALSE` preserves the historical behavior of relying on
-    # `chol()` to error on a singular covariance rather than the friendly guard.
+    # `check_singular = FALSE` preserves the historical behavior of letting the
+    # factorization catch a singular covariance rather than the up-front
+    # observations-vs-predictors guard.
     data <- metric_transform(data, distance, check_singular = FALSE)
     d <- as.matrix(stats::dist(data))
     if (distance == "cosine") {

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -8,6 +8,36 @@
       i 4 observations were found but 5 predictors are present.
       i Try a different `distance` metric or reduce the number of predictors.
 
+# mahalanobis errors informatively for collinear predictors (#246)
+
+    Code
+      nn_indices(data, 1, "mahalanobis")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "mahalanobis"` requires an invertible covariance matrix, but the covariance of the predictors is singular.
+      i This happens when predictors are collinear or constant, or when duplicated rows leave too few distinct observations.
+      i Try a different `distance` metric or remove the redundant predictors.
+
+---
+
+    Code
+      nn_indices(data, 1, "mahalanobis")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "mahalanobis"` requires an invertible covariance matrix, but the covariance of the predictors is singular.
+      i This happens when predictors are collinear or constant, or when duplicated rows leave too few distinct observations.
+      i Try a different `distance` metric or remove the redundant predictors.
+
+---
+
+    Code
+      nn_indices(data, 1, "mahalanobis")
+    Condition
+      Error in `nn_indices()`:
+      ! `distance = "mahalanobis"` requires an invertible covariance matrix, but the covariance of the predictors is singular.
+      i This happens when predictors are collinear or constant, or when duplicated rows leave too few distinct observations.
+      i Try a different `distance` metric or remove the redundant predictors.
+
 # sqrt-embedded metrics reject non-distribution predictors
 
     Code

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -4,6 +4,20 @@ test_that("nn_indices() errors informatively for singular mahalanobis covariance
   expect_snapshot(error = TRUE, nn_indices(data, 1, "mahalanobis"))
 })
 
+test_that("mahalanobis errors informatively for collinear predictors (#246)", {
+  # Enough observations to pass the nrow/ncol guard, but x2 = 2 * x1
+  data <- cbind(x1 = c(1, 2, 3, 4, 5), x2 = c(2, 4, 6, 8, 10))
+  expect_snapshot(error = TRUE, nn_indices(data, 1, "mahalanobis"))
+
+  # Constant column
+  data <- cbind(x1 = c(1, 2, 3, 4, 5), x2 = rep(1, 5))
+  expect_snapshot(error = TRUE, nn_indices(data, 1, "mahalanobis"))
+
+  # Duplicated rows leave too few distinct observations
+  data <- matrix(rep(c(1, 2, 3), each = 5), nrow = 5)
+  expect_snapshot(error = TRUE, nn_indices(data, 1, "mahalanobis"))
+})
+
 test_that("nn_indices() uses the correct distance metric", {
   # Each case is constructed so the nearest neighbor differs by metric.
   # Row 1 is the query point; we check which of rows 2/3 it picks as neighbor.


### PR DESCRIPTION
Closes #246. `distance = "mahalanobis"` already guarded against having more predictors than observations, but a covariance matrix can also be singular from collinear or constant predictors, or from duplicated rows, and those cases surfaced as a raw "leading minor is not positive definite" message from `chol()`.

Worth flagging beyond what the issue described: with exactly collinear predictors `chol()` did not error at all. Rounding left the offending pivot a tiny positive number, so the factorization succeeded and `solve()` returned an inverse of magnitude ~1e7, silently poisoning every distance. That is why the fix rank-checks the covariance up front rather than only wrapping `chol()`.