### PR TITLE
Expose m_neighbors and out_step in SVM-SMOTE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,8 @@
 
 * `step_smotenc()` now validates that all predictors are numeric or nominal, erroring on unsupported column types such as dates instead of failing later (#254).
 
+* `step_svmsmote()` (and its direct-implementation counterpart `svmsmote()`) gains `m_neighbors` and `out_step` arguments, which were previously hard-coded, controlling how many neighbors are used to label support vectors as noise, danger, or safe and how far new examples are extrapolated from safe support vectors. `m_neighbors` is also tunable, and the fixed choices made when fitting the support vector machine are now documented (#270).
+
 * `step_svmsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
 
 ## Bug fixes

--- a/R/svmsmote.R
+++ b/R/svmsmote.R
@@ -15,6 +15,11 @@
 #'  be populated (eventually) by the `...` selectors.
 #' @param neighbors An integer. Number of nearest neighbor that are used
 #'  to generate the new examples of the minority class.
+#' @param m_neighbors An integer or `NULL`. Number of nearest neighbors, among
+#'  all classes, that are used to label each minority support vector as noise,
+#'  danger, or safe. Defaults to `NULL`, which means `2 * neighbors`.
+#' @param out_step A number. Step size used when extrapolating new examples
+#'  away from safe support vectors. Defaults to 0.5.
 #' @inheritParams step_smote
 #' @param seed An integer that will be used as the seed when applied.
 #' @return An updated version of `recipe` with the new step
@@ -118,6 +123,8 @@ step_svmsmote <-
     over_ratio = 1,
     neighbors = 5,
     distance = "euclidean",
+    m_neighbors = NULL,
+    out_step = 0.5,
     indicator_column = NULL,
     skip = TRUE,
     seed = sample.int(10^5, 1),
@@ -137,6 +144,8 @@ step_svmsmote <-
         over_ratio = over_ratio,
         neighbors = neighbors,
         distance = distance,
+        m_neighbors = m_neighbors,
+        out_step = out_step,
         predictors = NULL,
         indicator_column = indicator_column,
         skip = skip,
@@ -155,6 +164,8 @@ step_svmsmote_new <-
     over_ratio,
     neighbors,
     distance,
+    m_neighbors,
+    out_step,
     predictors,
     indicator_column,
     skip,
@@ -170,6 +181,8 @@ step_svmsmote_new <-
       over_ratio = over_ratio,
       neighbors = neighbors,
       distance = distance,
+      m_neighbors = m_neighbors,
+      out_step = out_step,
       predictors = predictors,
       indicator_column = indicator_column,
       skip = skip,
@@ -184,6 +197,13 @@ prep.step_svmsmote <- function(x, training, info = NULL, ...) {
 
   check_number_decimal(x$over_ratio, arg = "over_ratio", min = 0)
   check_number_whole(x$neighbors, arg = "neighbors", min = 1)
+  check_number_whole(
+    x$m_neighbors,
+    arg = "m_neighbors",
+    min = 1,
+    allow_null = TRUE
+  )
+  check_number_decimal(x$out_step, arg = "out_step", min = 0)
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
@@ -209,6 +229,8 @@ prep.step_svmsmote <- function(x, training, info = NULL, ...) {
     over_ratio = x$over_ratio,
     neighbors = x$neighbors,
     distance = x$distance,
+    m_neighbors = x$m_neighbors,
+    out_step = x$out_step,
     predictors = predictors,
     indicator_column = x$indicator_column,
     skip = x$skip,
@@ -244,7 +266,9 @@ bake.step_svmsmote <- function(object, new_data, ...) {
         object$column,
         k = object$neighbors,
         over_ratio = object$over_ratio,
-        distance = object$distance
+        distance = object$distance,
+        m_neighbors = object$m_neighbors,
+        out_step = object$out_step
       )
       synthetic_data <- as_tibble(synthetic_data)
     }
@@ -282,10 +306,11 @@ tidy.step_svmsmote <- function(x, ...) {
 #' @rdname tunable_themis
 tunable.step_svmsmote <- function(x, ...) {
   tibble::tibble(
-    name = c("over_ratio", "neighbors"),
+    name = c("over_ratio", "neighbors", "m_neighbors"),
     call_info = list(
       list(pkg = "dials", fun = "over_ratio"),
-      list(pkg = "dials", fun = "neighbors", range = c(1, 10))
+      list(pkg = "dials", fun = "neighbors", range = c(1, 10)),
+      list(pkg = "dials", fun = "neighbors", range = c(1, 20))
     ),
     source = "recipe",
     component = "step_svmsmote",

--- a/R/svmsmote_impl.R
+++ b/R/svmsmote_impl.R
@@ -10,6 +10,11 @@
 #' @param var Character, name of variable containing factor variable.
 #' @param k An integer. Number of nearest neighbor that are used
 #'  to generate the new examples of the minority class.
+#' @param m_neighbors An integer or `NULL`. Number of nearest neighbors, among
+#'  all classes, that are used to label each minority support vector as noise,
+#'  danger, or safe. Defaults to `NULL`, which means `2 * k`.
+#' @param out_step A number. Step size used when extrapolating new examples
+#'  away from safe support vectors. Defaults to 0.5.
 #'
 #' @return A data.frame or tibble, depending on type of `df`.
 #' @export
@@ -38,19 +43,39 @@
 #' res <- svmsmote(circle_numeric, var = "class", over_ratio = 0.8)
 #'
 #' res <- svmsmote(circle_numeric, var = "class", distance = "manhattan")
-svmsmote <- function(df, var, k = 5, over_ratio = 1, distance = "euclidean") {
+#'
+#' res <- svmsmote(circle_numeric, var = "class", m_neighbors = 20)
+svmsmote <- function(
+  df,
+  var,
+  k = 5,
+  over_ratio = 1,
+  distance = "euclidean",
+  m_neighbors = NULL,
+  out_step = 0.5
+) {
   check_data_frame(df)
   check_var(var, df)
   check_number_whole(k, min = 1)
   check_number_decimal(over_ratio)
   check_distance_arg(distance)
+  check_number_whole(m_neighbors, min = 1, allow_null = TRUE)
+  check_number_decimal(out_step, min = 0)
 
   predictors <- setdiff(colnames(df), var)
 
   check_numeric(df[, predictors])
   check_na(select(df, -all_of(var)))
 
-  svmsmote_impl(df, var, k, over_ratio, distance)
+  svmsmote_impl(
+    df,
+    var,
+    k,
+    over_ratio,
+    distance,
+    m_neighbors = m_neighbors,
+    out_step = out_step
+  )
 }
 
 svmsmote_impl <- function(
@@ -59,13 +84,27 @@ svmsmote_impl <- function(
   k = 5,
   over_ratio = 1,
   distance = "euclidean",
+  m_neighbors = NULL,
+  out_step = 0.5,
   call = caller_env()
 ) {
   df[[var]] <- as.factor(df[[var]])
   # `m` neighbors are used to classify support vectors as noise, danger, or
   # safety; `out_step` controls how far extrapolated examples are placed.
-  m <- 2 * k
-  out_step <- 0.5
+  if (is.null(m_neighbors)) {
+    m <- min(2 * k, nrow(df) - 1)
+  } else {
+    m <- m_neighbors
+    if (m >= nrow(df)) {
+      cli::cli_abort(
+        c(
+          "{.arg m_neighbors} must be less than the number of observations.",
+          i = "{m} neighbor{?s} {?was/were} requested, but only {nrow(df)} observation{?s} {?is/are} available."
+        ),
+        call = call
+      )
+    }
+  }
 
   counts <- table(drop_unused_levels(df[[var]]))
   majority_count <- max(counts)

--- a/man-roxygen/details-svmsmote.R
+++ b/man-roxygen/details-svmsmote.R
@@ -12,3 +12,14 @@
 #' points are interpolated between it and its minority-class neighbors. The
 #' remaining support vectors are considered to be in a safe region and new points
 #' are extrapolated away from their minority-class neighbors.
+#'
+#' The number of neighbors used for this labeling is controlled by
+#' `m_neighbors`, and how far the extrapolated points are placed is controlled by
+#' `out_step`.
+#'
+#' The support vector machine is always fitted with [kernlab::ksvm()] using a
+#' radial basis function kernel (`kernel = "rbfdot"`) and a cost of `C = 1`,
+#' matching the reference implementations of the method. These are not exposed
+#' as arguments because the fitted model is only used to identify which minority
+#' observations are support vectors, and not for prediction, so the sampling
+#' results are relatively insensitive to them.

--- a/man/step_svmsmote.Rd
+++ b/man/step_svmsmote.Rd
@@ -14,6 +14,8 @@ step_svmsmote(
   over_ratio = 1,
   neighbors = 5,
   distance = "euclidean",
+  m_neighbors = NULL,
+  out_step = 0.5,
   indicator_column = NULL,
   skip = TRUE,
   seed = sample.int(10^5, 1),
@@ -77,6 +79,13 @@ The probability divergences are meaningful for compositional predictors such
 as proportions or counts normalized per observation, and are generally not
 appropriate for standardized predictors.}
 
+\item{m_neighbors}{An integer or \code{NULL}. Number of nearest neighbors, among
+all classes, that are used to label each minority support vector as noise,
+danger, or safe. Defaults to \code{NULL}, which means \code{2 * neighbors}.}
+
+\item{out_step}{A number. Step size used when extrapolating new examples
+away from safe support vectors. Defaults to 0.5.}
+
 \item{indicator_column}{A single string or \code{NULL} (the default). If a
 string is given, a logical column with that name is added to the output,
 marking rows added by the step (\code{TRUE}) vs rows from the original data
@@ -118,6 +127,17 @@ points are interpolated between it and its minority-class neighbors. The
 remaining support vectors are considered to be in a safe region and new points
 are extrapolated away from their minority-class neighbors.
 
+The number of neighbors used for this labeling is controlled by
+\code{m_neighbors}, and how far the extrapolated points are placed is controlled by
+\code{out_step}.
+
+The support vector machine is always fitted with \code{\link[kernlab:ksvm]{kernlab::ksvm()}} using a
+radial basis function kernel (\code{kernel = "rbfdot"}) and a cost of \code{C = 1},
+matching the reference implementations of the method. These are not exposed
+as arguments because the fitted model is only used to identify which minority
+observations are support vectors, and not for prediction, so the sampling
+results are relatively insensitive to them.
+
 SMOTE generates new examples of the minority class using nearest neighbors
 of these cases. For each existing minority class example, new examples are
 created by interpolating between the example and its nearest neighbors. The
@@ -150,10 +170,11 @@ columns \code{terms} and \code{id}:
 }
 
 \section{Tuning Parameters}{
-This step has 2 tuning parameters:
+This step has 3 tuning parameters:
 \itemize{
 \item \code{over_ratio}: Over-Sampling Ratio (type: double, default: 1)
 \item \code{neighbors}: # Nearest Neighbors (type: integer, default: 5)
+\item \code{m_neighbors}: # Nearest Neighbors (type: integer, default: NULL)
 }
 }
 

--- a/man/svmsmote.Rd
+++ b/man/svmsmote.Rd
@@ -4,7 +4,15 @@
 \alias{svmsmote}
 \title{SVM-SMOTE Algorithm}
 \usage{
-svmsmote(df, var, k = 5, over_ratio = 1, distance = "euclidean")
+svmsmote(
+  df,
+  var,
+  k = 5,
+  over_ratio = 1,
+  distance = "euclidean",
+  m_neighbors = NULL,
+  out_step = 0.5
+)
 }
 \arguments{
 \item{df}{data.frame or tibble. Must have 1 factor variable and remaining
@@ -50,6 +58,13 @@ individual predictor values.
 The probability divergences are meaningful for compositional predictors such
 as proportions or counts normalized per observation, and are generally not
 appropriate for standardized predictors.}
+
+\item{m_neighbors}{An integer or \code{NULL}. Number of nearest neighbors, among
+all classes, that are used to label each minority support vector as noise,
+danger, or safe. Defaults to \code{NULL}, which means \code{2 * k}.}
+
+\item{out_step}{A number. Step size used when extrapolating new examples
+away from safe support vectors. Defaults to 0.5.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.
@@ -74,6 +89,17 @@ points are interpolated between it and its minority-class neighbors. The
 remaining support vectors are considered to be in a safe region and new points
 are extrapolated away from their minority-class neighbors.
 
+The number of neighbors used for this labeling is controlled by
+\code{m_neighbors}, and how far the extrapolated points are placed is controlled by
+\code{out_step}.
+
+The support vector machine is always fitted with \code{\link[kernlab:ksvm]{kernlab::ksvm()}} using a
+radial basis function kernel (\code{kernel = "rbfdot"}) and a cost of \code{C = 1},
+matching the reference implementations of the method. These are not exposed
+as arguments because the fitted model is only used to identify which minority
+observations are support vectors, and not for prediction, so the sampling
+results are relatively insensitive to them.
+
 SMOTE generates new examples of the minority class using nearest neighbors
 of these cases. For each existing minority class example, new examples are
 created by interpolating between the example and its nearest neighbors. The
@@ -94,6 +120,8 @@ res <- svmsmote(circle_numeric, var = "class", k = 10)
 res <- svmsmote(circle_numeric, var = "class", over_ratio = 0.8)
 
 res <- svmsmote(circle_numeric, var = "class", distance = "manhattan")
+
+res <- svmsmote(circle_numeric, var = "class", m_neighbors = 20)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/tests/testthat/_snaps/svmsmote.md
+++ b/tests/testthat/_snaps/svmsmote.md
@@ -109,6 +109,33 @@
       Error in `step_svmsmote()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+---
+
+    Code
+      prep(step_svmsmote(recipe(~., data = mtcars), m_neighbors = 0))
+    Condition
+      Error in `step_svmsmote()`:
+      Caused by error in `prep()`:
+      ! `m_neighbors` must be a whole number larger than or equal to 1 or `NULL`, not the number 0.
+
+---
+
+    Code
+      prep(step_svmsmote(recipe(~., data = mtcars), out_step = "yes"))
+    Condition
+      Error in `step_svmsmote()`:
+      Caused by error in `prep()`:
+      ! `out_step` must be a number, not the string "yes".
+
+# m_neighbors larger than the data errors
+
+    Code
+      svmsmote(df, "class", m_neighbors = nrow(df))
+    Condition
+      Error in `svmsmote()`:
+      ! `m_neighbors` must be less than the number of observations.
+      i 400 neighbors were requested, but only 400 observations are available.
+
 # unused outcome levels are skipped with a warning (#238)
 
     Code

--- a/tests/testthat/test-svmsmote.R
+++ b/tests/testthat/test-svmsmote.R
@@ -276,11 +276,12 @@ test_that("tunable", {
   rec <- recipe(~., data = mtcars) |>
     step_svmsmote(all_predictors())
   rec_param <- tunable.step_svmsmote(rec$steps[[1]])
-  expect_equal(rec_param$name, c("over_ratio", "neighbors"))
+  expect_equal(rec_param$name, c("over_ratio", "neighbors", "m_neighbors"))
   expect_equal(rec_param$call_info[[2]]$range, c(1, 10))
+  expect_equal(rec_param$call_info[[3]]$range, c(1, 20))
   expect_true(all(rec_param$source == "recipe"))
   expect_true(is.list(rec_param$call_info))
-  expect_equal(nrow(rec_param), 2)
+  expect_equal(nrow(rec_param), 3)
   expect_equal(
     names(rec_param),
     c("name", "call_info", "source", "component", "component_id")
@@ -340,6 +341,59 @@ test_that("bad args", {
     recipe(~., data = mtcars) |>
       step_svmsmote(seed = TRUE)
   )
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., data = mtcars) |>
+      step_svmsmote(m_neighbors = 0) |>
+      prep()
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., data = mtcars) |>
+      step_svmsmote(out_step = "yes") |>
+      prep()
+  )
+})
+
+test_that("m_neighbors and out_step affect generated points (#270)", {
+  skip_if_not_installed("kernlab")
+
+  df <- circle_example[c("x", "y", "class")]
+
+  withr::with_seed(1, default <- svmsmote(df, "class"))
+  withr::with_seed(1, res_m <- svmsmote(df, "class", m_neighbors = 40))
+  withr::with_seed(1, res_step <- svmsmote(df, "class", out_step = 2))
+
+  expect_equal(nrow(res_m), nrow(default))
+  expect_false(isTRUE(all.equal(res_m$x, default$x)))
+
+  expect_equal(nrow(res_step), nrow(default))
+  expect_false(isTRUE(all.equal(res_step$x, default$x)))
+})
+
+test_that("m_neighbors defaults to 2 * neighbors (#270)", {
+  skip_if_not_installed("kernlab")
+
+  df <- circle_example[c("x", "y", "class")]
+
+  withr::with_seed(1, res_default <- svmsmote(df, "class", k = 5))
+  withr::with_seed(
+    1,
+    res_explicit <- svmsmote(df, "class", k = 5, m_neighbors = 10)
+  )
+
+  expect_equal(res_default, res_explicit)
+})
+
+test_that("m_neighbors larger than the data errors", {
+  skip_if_not_installed("kernlab")
+
+  df <- circle_example[c("x", "y", "class")]
+
+  expect_snapshot(
+    error = TRUE,
+    svmsmote(df, "class", m_neighbors = nrow(df))
+  )
 })
 
 test_that("tunable is setup to works with extract_parameter_set_dials", {
@@ -348,13 +402,14 @@ test_that("tunable is setup to works with extract_parameter_set_dials", {
     step_svmsmote(
       all_predictors(),
       over_ratio = hardhat::tune(),
-      neighbors = hardhat::tune()
+      neighbors = hardhat::tune(),
+      m_neighbors = hardhat::tune()
     )
 
   params <- extract_parameter_set_dials(rec)
 
   expect_s3_class(params, "parameters")
-  expect_identical(nrow(params), 2L)
+  expect_identical(nrow(params), 3L)
 })
 
 test_that("unused outcome levels are skipped with a warning (#238)", {

--- a/tests/testthat/test-tunable.R
+++ b/tests/testthat/test-tunable.R
@@ -136,11 +136,15 @@ test_that("tunable.step_smotenc", {
 
 test_that("tunable.step_svmsmote", {
   res <- tune_tbl(step_svmsmote)
-  expect_equal(res$name, c("over_ratio", "neighbors"))
+  expect_equal(res$name, c("over_ratio", "neighbors", "m_neighbors"))
   expect_equal(res$call_info[[1]], list(pkg = "dials", fun = "over_ratio"))
   expect_equal(
     res$call_info[[2]],
     list(pkg = "dials", fun = "neighbors", range = c(1, 10))
+  )
+  expect_equal(
+    res$call_info[[3]],
+    list(pkg = "dials", fun = "neighbors", range = c(1, 20))
   )
   expect_all_equal(res$component, "step_svmsmote")
 })


### PR DESCRIPTION
Closes #270. `step_svmsmote()` and `svmsmote()` hard-coded the number of neighbors used to label support vectors as noise/danger/safe and the extrapolation step size, so users could neither tune them nor see what they were. Both are now arguments (`m_neighbors`, defaulting to `2 * neighbors`, and `out_step`), with `m_neighbors` registered as tunable.

The SVM fit itself stays fixed at `kernel = "rbfdot"` and `C = 1` rather than becoming user-facing, since the model is only used to identify which minority observations are support vectors; that choice and its rationale are now documented instead.