### PR TITLE
Add kind_sel argument to step_enn() and enn()

### DIFF
--- a/R/enn.R
+++ b/R/enn.R
@@ -26,6 +26,10 @@
 #'  of neighbors, from `1` up to `neighbors`, cleaning the data at each step
 #'  (All k-Nearest Neighbors). Takes precedence over `times`. Defaults to
 #'  `FALSE`.
+#' @param kind_sel A character string. The rule used to decide whether an
+#'  observation is removed. `"mode"` (the default) removes an observation when
+#'  the majority of its neighbors disagree with its class. `"all"` is stricter
+#'  and removes an observation unless all of its neighbors share its class.
 #' @param seed An integer that will be used as the seed when
 #' applied.
 #' @return An updated version of `recipe` with the new step
@@ -142,6 +146,7 @@ step_enn <-
     distance = "euclidean",
     times = 1,
     all_k = FALSE,
+    kind_sel = "mode",
     skip = TRUE,
     seed = sample.int(10^5, 1),
     distance_with = recipes::all_predictors(),
@@ -149,6 +154,7 @@ step_enn <-
   ) {
     check_number_whole(seed)
     check_distance_arg(distance)
+    kind_sel <- rlang::arg_match(kind_sel, c("mode", "all"))
 
     add_step(
       recipe,
@@ -161,6 +167,7 @@ step_enn <-
         distance = distance,
         times = times,
         all_k = all_k,
+        kind_sel = kind_sel,
         predictors = NULL,
         skip = skip,
         seed = seed,
@@ -180,6 +187,7 @@ step_enn_new <-
     distance,
     times,
     all_k,
+    kind_sel,
     predictors,
     skip,
     seed,
@@ -196,6 +204,7 @@ step_enn_new <-
       distance = distance,
       times = times,
       all_k = all_k,
+      kind_sel = kind_sel,
       predictors = predictors,
       skip = skip,
       seed = seed,
@@ -238,6 +247,7 @@ prep.step_enn <- function(x, training, info = NULL, ...) {
     distance = x$distance,
     times = x$times,
     all_k = x$all_k,
+    kind_sel = x$kind_sel,
     predictors = predictors,
     skip = x$skip,
     seed = x$seed,
@@ -272,7 +282,8 @@ bake.step_enn <- function(object, new_data, ...) {
         neighbors = object$neighbors,
         distance = object$distance,
         times = object$times,
-        all_k = object$all_k
+        all_k = object$all_k,
+        kind_sel = object$kind_sel
       )
     }
   )

--- a/R/enn_impl.R
+++ b/R/enn_impl.R
@@ -42,13 +42,17 @@
 #'
 #' # All k-Nearest Neighbors (AllKNN)
 #' res <- enn(circle_numeric, var = "class", all_k = TRUE)
+#'
+#' # Stricter cleaning: remove unless all neighbors agree
+#' res <- enn(circle_numeric, var = "class", kind_sel = "all")
 enn <- function(
   df,
   var,
   neighbors = 3,
   distance = "euclidean",
   times = 1,
-  all_k = FALSE
+  all_k = FALSE,
+  kind_sel = "mode"
 ) {
   check_data_frame(df)
   check_var(var, df)
@@ -57,13 +61,22 @@ enn <- function(
   check_number_whole(times, min = 1, allow_infinite = TRUE)
   check_bool(all_k)
   warn_times_all_k(times, all_k)
+  kind_sel <- rlang::arg_match(kind_sel, c("mode", "all"))
 
   predictors <- setdiff(colnames(df), var)
 
   check_numeric(df[, predictors])
   check_na(select(df, -all_of(var)))
 
-  remove <- enn_impl(df, var, neighbors, distance, times = times, all_k = all_k)
+  remove <- enn_impl(
+    df,
+    var,
+    neighbors,
+    distance,
+    times = times,
+    all_k = all_k,
+    kind_sel = kind_sel
+  )
   if (length(remove) > 0) {
     df <- df[-remove, ]
   }
@@ -77,6 +90,7 @@ enn_impl <- function(
   distance = "euclidean",
   times = 1,
   all_k = FALSE,
+  kind_sel = "mode",
   call = caller_env()
 ) {
   if (nrow(df) <= neighbors) {
@@ -106,7 +120,13 @@ enn_impl <- function(
       break
     }
 
-    remove <- enn_single(df[active, , drop = FALSE], var, k, distance)
+    remove <- enn_single(
+      df[active, , drop = FALSE],
+      var,
+      k,
+      distance,
+      kind_sel = kind_sel
+    )
 
     if (length(remove) == 0) {
       # RENN stops early at convergence; AllKNN continues with a larger k
@@ -134,7 +154,7 @@ warn_times_all_k <- function(times, all_k, call = caller_env()) {
 
 # A single pass of Edited Nearest Neighbors. Returns the row indices of `df`
 # that should be removed.
-enn_single <- function(df, var, neighbors, distance) {
+enn_single <- function(df, var, neighbors, distance, kind_sel = "mode") {
   outcome <- df[[var]]
 
   idx <- nn_indices(as.matrix(df[names(df) != var]), k = neighbors, distance)
@@ -148,7 +168,15 @@ enn_single <- function(df, var, neighbors, distance) {
     ncol = ncol(idx)
   )
 
-  neighbor_mode <- apply(neighbor_classes, 1, Mode)
+  outcome <- as.character(outcome)
 
-  which(as.character(outcome) != as.character(neighbor_mode))
+  if (kind_sel == "all") {
+    # Stricter rule: keep an observation only when all neighbors agree with it
+    disagrees <- rowSums(neighbor_classes != outcome) > 0
+  } else {
+    neighbor_mode <- apply(neighbor_classes, 1, Mode)
+    disagrees <- outcome != as.character(neighbor_mode)
+  }
+
+  which(disagrees)
 }

--- a/man-roxygen/details-enn.R
+++ b/man-roxygen/details-enn.R
@@ -13,3 +13,8 @@
 #' Setting `all_k = TRUE` applies ENN with increasing numbers of neighbors, from
 #' `1` up to `neighbors`, cleaning the data at each step. This corresponds to
 #' All k-Nearest Neighbors (AllKNN) and takes precedence over `times`.
+#'
+#' Setting `kind_sel = "all"` uses a stricter cleaning rule: instead of removing
+#' an observation when the majority of its neighbors disagree, it is removed
+#' unless every one of its neighbors shares its class. This removes more
+#' observations than the default `kind_sel = "mode"`.

--- a/man/enn.Rd
+++ b/man/enn.Rd
@@ -4,7 +4,15 @@
 \alias{enn}
 \title{Edited Nearest Neighbors}
 \usage{
-enn(df, var, neighbors = 3, distance = "euclidean", times = 1, all_k = FALSE)
+enn(
+  df,
+  var,
+  neighbors = 3,
+  distance = "euclidean",
+  times = 1,
+  all_k = FALSE,
+  kind_sel = "mode"
+)
 }
 \arguments{
 \item{df}{data.frame or tibble. Must have 1 factor variable and remaining
@@ -53,6 +61,11 @@ the cleaning, stopping early once a pass removes no observations. Use
 of neighbors, from \code{1} up to \code{neighbors}, cleaning the data at each step
 (All k-Nearest Neighbors). Takes precedence over \code{times}. Defaults to
 \code{FALSE}.}
+
+\item{kind_sel}{A character string. The rule used to decide whether an
+observation is removed. \code{"mode"} (the default) removes an observation when
+the majority of its neighbors disagree with its class. \code{"all"} is stricter
+and removes an observation unless all of its neighbors share its class.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.
@@ -77,6 +90,11 @@ Setting \code{all_k = TRUE} applies ENN with increasing numbers of neighbors, fr
 \code{1} up to \code{neighbors}, cleaning the data at each step. This corresponds to
 All k-Nearest Neighbors (AllKNN) and takes precedence over \code{times}.
 
+Setting \code{kind_sel = "all"} uses a stricter cleaning rule: instead of removing
+an observation when the majority of its neighbors disagree, it is removed
+unless every one of its neighbors shares its class. This removes more
+observations than the default \code{kind_sel = "mode"}.
+
 All columns used in this function must be numeric with no missing data.
 
 Use \code{times = Inf} to repeat ENN until convergence.
@@ -95,6 +113,9 @@ res <- enn(circle_numeric, var = "class", times = Inf)
 
 # All k-Nearest Neighbors (AllKNN)
 res <- enn(circle_numeric, var = "class", all_k = TRUE)
+
+# Stricter cleaning: remove unless all neighbors agree
+res <- enn(circle_numeric, var = "class", kind_sel = "all")
 }
 \references{
 Wilson, D. L. (1972). Asymptotic properties of nearest neighbor

--- a/man/step_enn.Rd
+++ b/man/step_enn.Rd
@@ -15,6 +15,7 @@ step_enn(
   distance = "euclidean",
   times = 1,
   all_k = FALSE,
+  kind_sel = "mode",
   skip = TRUE,
   seed = sample.int(10^5, 1),
   distance_with = recipes::all_predictors(),
@@ -82,6 +83,11 @@ of neighbors, from \code{1} up to \code{neighbors}, cleaning the data at each st
 (All k-Nearest Neighbors). Takes precedence over \code{times}. Defaults to
 \code{FALSE}.}
 
+\item{kind_sel}{A character string. The rule used to decide whether an
+observation is removed. \code{"mode"} (the default) removes an observation when
+the majority of its neighbors disagree with its class. \code{"all"} is stricter
+and removes an observation unless all of its neighbors share its class.}
+
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some
 operations may not be able to be conducted on new data (e.g. processing the
@@ -124,6 +130,11 @@ removes nothing. This corresponds to Repeated Edited Nearest Neighbors
 Setting \code{all_k = TRUE} applies ENN with increasing numbers of neighbors, from
 \code{1} up to \code{neighbors}, cleaning the data at each step. This corresponds to
 All k-Nearest Neighbors (AllKNN) and takes precedence over \code{times}.
+
+Setting \code{kind_sel = "all"} uses a stricter cleaning rule: instead of removing
+an observation when the majority of its neighbors disagree, it is removed
+unless every one of its neighbors shares its class. This removes more
+observations than the default \code{kind_sel = "mode"}.
 
 All variables selected by \code{distance_with} must be numeric with no missing
 data.

--- a/tests/testthat/_snaps/enn.md
+++ b/tests/testthat/_snaps/enn.md
@@ -1,3 +1,21 @@
+# kind_sel is validated
+
+    Code
+      enn(circle_example[, c("x", "y", "class")], "class", kind_sel = "most")
+    Condition
+      Error in `enn()`:
+      ! `kind_sel` must be one of "mode" or "all", not "most".
+      i Did you mean "mode"?
+
+---
+
+    Code
+      step_enn(recipe(class ~ x + y, data = circle_example), class, kind_sel = "most")
+    Condition
+      Error in `step_enn()`:
+      ! `kind_sel` must be one of "mode" or "all", not "most".
+      i Did you mean "mode"?
+
 # warns when both times and all_k are set
 
     Code

--- a/tests/testthat/test-enn.R
+++ b/tests/testthat/test-enn.R
@@ -84,6 +84,50 @@ test_that("all_k argument accepted by step_enn()", {
   )
 })
 
+test_that("kind_sel = 'all' removes at least as much as 'mode'", {
+  circle_numeric <- circle_example[, c("x", "y", "class")]
+
+  n_mode <- nrow(enn(circle_numeric, var = "class", kind_sel = "mode"))
+  n_all <- nrow(enn(circle_numeric, var = "class", kind_sel = "all"))
+
+  expect_lt(n_all, n_mode)
+})
+
+test_that("kind_sel = 'all' removes a superset of what 'mode' removes", {
+  circle_numeric <- circle_example[, c("x", "y", "class")]
+
+  mode_removed <- enn_impl(circle_numeric, var = "class", kind_sel = "mode")
+  all_removed <- enn_impl(circle_numeric, var = "class", kind_sel = "all")
+
+  expect_all_true(mode_removed %in% all_removed)
+})
+
+test_that("kind_sel argument accepted by step_enn()", {
+  baked <- recipe(class ~ x + y, data = circle_example) |>
+    step_enn(class, kind_sel = "all") |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_identical(
+    baked,
+    tibble::as_tibble(
+      enn(circle_example[, c("x", "y", "class")], "class", kind_sel = "all")
+    )[, c("x", "y", "class")]
+  )
+})
+
+test_that("kind_sel is validated", {
+  expect_snapshot(
+    error = TRUE,
+    enn(circle_example[, c("x", "y", "class")], "class", kind_sel = "most")
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(class ~ x + y, data = circle_example) |>
+      step_enn(class, kind_sel = "most")
+  )
+})
+
 test_that("warns when both times and all_k are set", {
   expect_snapshot(
     tmp <- enn(

--- a/tests/testthat/test-enn_impl.R
+++ b/tests/testthat/test-enn_impl.R
@@ -30,6 +30,21 @@ test_that("all_k removes at least as much as a single pass", {
   expect_all_true(single %in% allk)
 })
 
+test_that("kind_sel = 'all' removes borderline points that 'mode' keeps", {
+  df <- data.frame(
+    x = c(0, 0.1, 0.2, 0.3, 0.4, 10, 10.1, 10.2),
+    y = rep(0, 8),
+    class = factor(c("a", "a", "a", "a", "b", "b", "b", "b"))
+  )
+  # Point 4 (x = 0.3, class a) has one "b" among its 3 neighbors, so it
+  # survives the mode rule but not the all rule.
+  expect_identical(enn_impl(df, var = "class", neighbors = 3), 5L)
+  expect_identical(
+    enn_impl(df, var = "class", neighbors = 3, kind_sel = "all"),
+    c(4L, 5L)
+  )
+})
+
 test_that("enn_impl() errors when too few observations for neighbors", {
   df <- data.frame(
     x = c(0, 1, 2),


### PR DESCRIPTION
Adds a `kind_sel` argument to `step_enn()` and `enn()` for choosing the ENN cleaning rule, matching imbalanced-learn's `EditedNearestNeighbours`. The default `"mode"` preserves Wilson's majority vote (themis's current behavior), while `"all"` is stricter and drops an observation unless every neighbor shares its class. It flows through to RENN and AllKNN automatically since both reuse the same single-pass helper.

`step_ncl()` is untouched: its A1 stage corresponds to ENN with the mode rule and does not route through this code path.

No NEWS bullet, since `step_enn()` itself is new in this development version.

Fixes #324.