### PR TITLE
Add replacement argument to step_downsample()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
 
 * `step_bsmote()` now sets the tuning range of its `neighbors` parameter to `c(1, 10)`, matching the other steps that tune `neighbors` (#254).
 
+* `step_downsample()` gains a `replacement` argument. When set to `TRUE` the under-sample is drawn with replacement, giving a bootstrapped under-sample where the same row can be selected more than once. The default `FALSE` keeps the current behavior (#325).
+
 * `step_enn()` (and its direct-implementation counterpart `enn()`) gain a `times` argument to apply the cleaning repeatedly, stopping early on convergence, which corresponds to Repeated Edited Nearest Neighbors (RENN) (#173).
 
 * `step_enn()` (and its direct-implementation counterpart `enn()`) gain an `all_k` argument to apply the cleaning with an increasing number of neighbors, from 1 up to `neighbors`, which corresponds to All k-Nearest Neighbors (AllKNN) (#174).

--- a/R/downsample.R
+++ b/R/downsample.R
@@ -22,6 +22,13 @@
 #'  twice as many rows than the minority level. See
 #'  `vignette("ratio", package = "themis")` for more details.
 #' @param ratio Deprecated argument; same as `under_ratio`
+#' @param replacement A logical value indicating whether the
+#'  under-sample should be drawn with replacement. Defaults to
+#'  `FALSE`, in which case each retained row is distinct. When
+#'  `TRUE` the same row can be selected more than once, giving a
+#'  bootstrapped under-sample. The number of rows retained for each
+#'  level is unaffected, so no level is sampled up beyond its
+#'  original size.
 #' @param target An integer that will be used to subsample. This
 #'  should not be set by the user and will be populated by `prep`.
 #' @param seed An integer that will be used as the seed when applied.
@@ -124,6 +131,7 @@ step_downsample <-
     ...,
     under_ratio = 1,
     ratio = deprecated(),
+    replacement = FALSE,
     role = NA,
     trained = FALSE,
     column = NULL,
@@ -140,6 +148,7 @@ step_downsample <-
       )
     }
     check_number_whole(seed)
+    check_bool(replacement)
 
     add_step(
       recipe,
@@ -147,6 +156,7 @@ step_downsample <-
         terms = enquos(...),
         under_ratio = under_ratio,
         ratio = NULL,
+        replacement = replacement,
         role = role,
         trained = trained,
         column = column,
@@ -164,6 +174,7 @@ step_downsample_new <-
     terms,
     under_ratio,
     ratio,
+    replacement,
     role,
     trained,
     column,
@@ -178,6 +189,7 @@ step_downsample_new <-
       terms = terms,
       under_ratio = under_ratio,
       ratio = ratio,
+      replacement = replacement,
       role = role,
       trained = trained,
       column = column,
@@ -219,6 +231,7 @@ prep.step_downsample <- function(x, training, info = NULL, ...) {
     terms = x$terms,
     under_ratio = x$under_ratio,
     ratio = x$ratio,
+    replacement = x$replacement,
     role = x$role,
     trained = TRUE,
     column = col_name,
@@ -231,16 +244,15 @@ prep.step_downsample <- function(x, training, info = NULL, ...) {
 }
 
 
-subsamp <- function(x, wts, num) {
+subsamp <- function(x, wts, num, replace = FALSE) {
   n <- nrow(x)
   if (n == 0) {
     return(x)
   }
-  if (nrow(x) == num) {
+  if (!replace && n == num) {
     out <- x
   } else {
-    # downsampling is done without replacement
-    out <- x[sample(seq_len(n), min(num, n), prob = wts), ]
+    out <- x[sample(seq_len(n), min(num, n), replace = replace, prob = wts), ]
   }
   out
 }
@@ -283,13 +295,19 @@ bake.step_downsample <- function(object, new_data, ...) {
         split_data,
         split_wts,
         subsamp,
-        num = object$target
+        num = object$target,
+        replace = isTRUE(object$replacement)
       ) |>
         purrr::list_rbind()
       if (!is.null(missing)) {
         new_data <- bind_rows(
           new_data,
-          subsamp(missing, wts = rep(1, nrow(missing)), num = object$target)
+          subsamp(
+            missing,
+            wts = rep(1, nrow(missing)),
+            num = object$target,
+            replace = isTRUE(object$replacement)
+          )
         )
       }
     }

--- a/man/step_downsample.Rd
+++ b/man/step_downsample.Rd
@@ -10,6 +10,7 @@ step_downsample(
   ...,
   under_ratio = 1,
   ratio = deprecated(),
+  replacement = FALSE,
   role = NA,
   trained = FALSE,
   column = NULL,
@@ -38,6 +39,14 @@ twice as many rows than the minority level. See
 \code{vignette("ratio", package = "themis")} for more details.}
 
 \item{ratio}{Deprecated argument; same as \code{under_ratio}}
+
+\item{replacement}{A logical value indicating whether the
+under-sample should be drawn with replacement. Defaults to
+\code{FALSE}, in which case each retained row is distinct. When
+\code{TRUE} the same row can be selected more than once, giving a
+bootstrapped under-sample. The number of rows retained for each
+level is unaffected, so no level is sampled up beyond its
+original size.}
 
 \item{role}{Not used by this step since no new variables are
 created.}

--- a/tests/testthat/_snaps/downsample.md
+++ b/tests/testthat/_snaps/downsample.md
@@ -80,6 +80,14 @@
       Error in `step_downsample()`:
       ! `seed` must be a whole number, not `TRUE`.
 
+---
+
+    Code
+      step_downsample(recipe(~., data = mtcars), replacement = "yes")
+    Condition
+      Error in `step_downsample()`:
+      ! `replacement` must be `TRUE` or `FALSE`, not the string "yes".
+
 # unused outcome levels are skipped with a warning (#238)
 
     Code

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -109,6 +109,40 @@ test_that("ratio value works when undersampling", {
   )
 })
 
+test_that("replacement = TRUE gives a bootstrapped under-sample", {
+  res <- recipe(~., data = circle_example) |>
+    step_downsample(class, replacement = TRUE, seed = 1) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(
+    as.vector(table(res$class)),
+    rep(min(table(circle_example$class)), length(table(res$class)))
+  )
+  expect_lt(nrow(dplyr::distinct(res)), nrow(res))
+})
+
+test_that("replacement = FALSE doesn't duplicate rows", {
+  res <- recipe(~., data = circle_example) |>
+    step_downsample(class, replacement = FALSE, seed = 1) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(nrow(dplyr::distinct(res)), nrow(res))
+})
+
+test_that("replacement = TRUE resamples the minority level too", {
+  res <- recipe(~., data = circle_example) |>
+    step_downsample(class, replacement = TRUE, seed = 1) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  minority <- names(which.min(table(circle_example$class)))
+  minority_rows <- dplyr::filter(res, class == minority)
+
+  expect_lt(nrow(dplyr::distinct(minority_rows)), nrow(minority_rows))
+})
+
 test_that("allows multi-class", {
   skip_if_not_installed("modeldata")
 
@@ -255,6 +289,11 @@ test_that("bad args", {
     error = TRUE,
     recipe(~., data = mtcars) |>
       step_downsample(seed = TRUE)
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., data = mtcars) |>
+      step_downsample(replacement = "yes")
   )
 })
 


### PR DESCRIPTION
`step_downsample()` gains a `replacement` argument, matching imbalanced-learn's `RandomUnderSampler`, so the under-sample can be drawn with replacement to give a bootstrapped under-sample. The default `FALSE` preserves the current behavior of distinct retained rows.

The draw stays capped at each level's original size, so `replacement = TRUE` never samples a level up, it only resamples the rows it keeps. Fixes #325.