### PR TITLE
Add NearMiss-2 and NearMiss-3 variants to step_nearmiss()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,8 @@
 
 * `step_ncl()` now documents that `neighbors` defaults to `3` (rather than `5` as in the over-sampling steps) and exposes `threshold_clean` as a tunable parameter (#254).
 
+* `step_nearmiss()` (and its direct-implementation counterpart `nearmiss()`) gains a `version` argument to select between the NearMiss-1, NearMiss-2, and NearMiss-3 variants of Mani & Zhang (2003), together with `n_neighbors_ver3` to control the size of the NearMiss-3 candidate pool. The default `version = 1` preserves the previous behavior (#279).
+
 * `step_nearmiss()` and `step_tomek()` gain a `distance_with` argument to control which variables are used for distance calculations. This allows the steps to be used when non-numeric predictor variables are present in the data (#166).
 
 * `step_rose()` now validates predictor types during `prep()`, giving a clear error for unsupported types consistent with the other sampling steps instead of relying on `ROSE::ROSE()` to fail downstream (#265).

--- a/R/nearmiss.R
+++ b/R/nearmiss.R
@@ -22,6 +22,11 @@
 #'  always excluded from the distance calculations.
 #' @param seed An integer that will be used as the seed when
 #' applied.
+#' @param version An integer. Which of the three NearMiss variants to use,
+#'  `1`, `2`, or `3`. Defaults to `1`. See the details section.
+#' @param n_neighbors_ver3 An integer. The number of nearest neighbors used
+#'  to build the candidate pool of the NearMiss-3 variant. Only used when
+#'  `version = 3`. Defaults to `3`.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps (if any). For the
 #'  `tidy` method, a tibble with columns `terms` which is
@@ -132,6 +137,8 @@ step_nearmiss <-
     under_ratio = 1,
     neighbors = 5,
     distance = "euclidean",
+    version = 1,
+    n_neighbors_ver3 = 3,
     skip = TRUE,
     seed = sample.int(10^5, 1),
     distance_with = recipes::all_predictors(),
@@ -139,6 +146,8 @@ step_nearmiss <-
   ) {
     check_number_whole(seed)
     check_distance_arg(distance)
+    check_number_whole(version, min = 1, max = 3)
+    check_number_whole(n_neighbors_ver3, min = 1)
 
     add_step(
       recipe,
@@ -150,6 +159,8 @@ step_nearmiss <-
         under_ratio = under_ratio,
         neighbors = neighbors,
         distance = distance,
+        version = version,
+        n_neighbors_ver3 = n_neighbors_ver3,
         predictors = NULL,
         skip = skip,
         seed = seed,
@@ -168,6 +179,8 @@ step_nearmiss_new <-
     under_ratio,
     neighbors,
     distance,
+    version,
+    n_neighbors_ver3,
     predictors,
     skip,
     seed,
@@ -183,6 +196,8 @@ step_nearmiss_new <-
       under_ratio = under_ratio,
       neighbors = neighbors,
       distance = distance,
+      version = version,
+      n_neighbors_ver3 = n_neighbors_ver3,
       predictors = predictors,
       skip = skip,
       seed = seed,
@@ -197,6 +212,12 @@ prep.step_nearmiss <- function(x, training, info = NULL, ...) {
 
   check_number_decimal(x$under_ratio, arg = "under_ratio", min = 0)
   check_number_whole(x$neighbors, arg = "neighbors", min = 1)
+  check_number_whole(x$version, arg = "version", min = 1, max = 3)
+  check_number_whole(
+    x$n_neighbors_ver3,
+    arg = "n_neighbors_ver3",
+    min = 1
+  )
 
   check_1_selected(col_name)
   check_column_factor(training, col_name)
@@ -222,6 +243,8 @@ prep.step_nearmiss <- function(x, training, info = NULL, ...) {
     under_ratio = x$under_ratio,
     neighbors = x$neighbors,
     distance = x$distance,
+    version = x$version,
+    n_neighbors_ver3 = x$n_neighbors_ver3,
     predictors = predictors,
     skip = x$skip,
     seed = x$seed,
@@ -257,7 +280,9 @@ bake.step_nearmiss <- function(object, new_data, ...) {
         ignore_vars = ignore_vars,
         k = object$neighbors,
         under_ratio = object$under_ratio,
-        distance = object$distance
+        distance = object$distance,
+        version = object$version,
+        n_neighbors_ver3 = object$n_neighbors_ver3
       )
       new_data[[object$column]] <- factor(
         new_data[[object$column]],
@@ -272,7 +297,7 @@ bake.step_nearmiss <- function(object, new_data, ...) {
 #' @export
 print.step_nearmiss <-
   function(x, width = max(20, options()$width - 26), ...) {
-    title <- "NEARMISS-1 based on "
+    title <- paste0("NEARMISS-", x$version, " based on ")
     print_step(x$column, x$terms, x$trained, title, width)
     invisible(x)
   }

--- a/R/nearmiss_impl.R
+++ b/R/nearmiss_impl.R
@@ -34,12 +34,33 @@
 #' res <- nearmiss(circle_numeric, var = "class", under_ratio = 1.5)
 #'
 #' res <- nearmiss(circle_numeric, var = "class", distance = "manhattan")
-nearmiss <- function(df, var, k = 5, under_ratio = 1, distance = "euclidean") {
+#'
+#' res <- nearmiss(circle_numeric, var = "class", version = 2)
+#'
+#' res <- nearmiss(circle_numeric, var = "class", version = 3)
+#'
+#' res <- nearmiss(
+#'   circle_numeric,
+#'   var = "class",
+#'   version = 3,
+#'   n_neighbors_ver3 = 10
+#' )
+nearmiss <- function(
+  df,
+  var,
+  k = 5,
+  under_ratio = 1,
+  distance = "euclidean",
+  version = 1,
+  n_neighbors_ver3 = 3
+) {
   check_data_frame(df)
   check_var(var, df)
   check_number_whole(k, min = 1)
   check_number_decimal(under_ratio)
   check_distance_arg(distance)
+  check_number_whole(version, min = 1, max = 3)
+  check_number_whole(n_neighbors_ver3, min = 1)
 
   predictors <- setdiff(colnames(df), var)
 
@@ -52,7 +73,9 @@ nearmiss <- function(df, var, k = 5, under_ratio = 1, distance = "euclidean") {
     ignore_vars = character(),
     k,
     under_ratio,
-    distance = distance
+    distance = distance,
+    version = version,
+    n_neighbors_ver3 = n_neighbors_ver3
   )
 }
 
@@ -63,6 +86,8 @@ nearmiss_impl <- function(
   k = 5,
   under_ratio = 1,
   distance = "euclidean",
+  version = 1,
+  n_neighbors_ver3 = 3,
   call = caller_env()
 ) {
   classes <- downsample_count(df, var, under_ratio)
@@ -83,10 +108,54 @@ nearmiss_impl <- function(
       )
     }
 
-    dists <- nn_dists_cross(class, not_class, k, distance)
+    n_keep <- nrow(class) - classes[i]
 
-    selected_ind <- rank(rowMeans(dists), ties.method = "first") <=
-      (nrow(class) - classes[i])
+    if (version == 1) {
+      dists <- nn_dists_cross(class, not_class, k, distance)
+      selected_ind <- rank(rowMeans(dists), ties.method = "first") <= n_keep
+    } else if (version == 2) {
+      # The k farthest neighbors instead of the k nearest ones. The distances
+      # returned by `nn_dists_cross()` are sorted increasingly, so requesting
+      # all of them and taking the last k columns gives the farthest ones.
+      dists <- nn_dists_cross(class, not_class, nrow(not_class), distance)
+      dists <- dists[, seq(ncol(dists) - k + 1, ncol(dists)), drop = FALSE]
+      selected_ind <- rank(rowMeans(dists), ties.method = "first") <= n_keep
+    } else {
+      if (n_neighbors_ver3 > nrow(class)) {
+        cli::cli_abort(
+          c(
+            "Not enough observations in {.val {names(classes)[i]}} to compute {n_neighbors_ver3} nearest neighbors for the NearMiss-3 candidate pool.",
+            i = "{nrow(class)} observation{?s} {?was/were} found, but {n_neighbors_ver3} {?is/are} needed.",
+            i = "Lower {.arg n_neighbors_ver3}."
+          ),
+          call = call
+        )
+      }
+
+      # First stage: for each observation of the other classes, keep its
+      # `n_neighbors_ver3` nearest neighbors within this class as candidates.
+      # Everything outside of that pool is removed.
+      pool_ind <- nn_indices_cross(
+        not_class,
+        class,
+        n_neighbors_ver3,
+        distance
+      )
+      pool <- sort(unique(as.vector(pool_ind)))
+
+      # Second stage: within the pool, keep the observations that are the
+      # farthest away from their k nearest neighbors in the other classes.
+      dists <- nn_dists_cross(
+        class[pool, , drop = FALSE],
+        not_class,
+        k,
+        distance
+      )
+      selected_ind <- rep(FALSE, nrow(class))
+      selected_ind[pool] <- rank(-rowMeans(dists), ties.method = "first") <=
+        n_keep
+    }
+
     deleted_rows <- c(
       deleted_rows,
       which(df[[var]] %in% names(classes)[i])[!selected_ind]

--- a/man-roxygen/details-nearmiss.R
+++ b/man-roxygen/details-nearmiss.R
@@ -1,7 +1,24 @@
 #' @details
-#' This implements the NearMiss-1 algorithm. It retains the points from the
-#' majority class which have the smallest mean distance to the nearest points
-#' in the minority class.
+#' The `version` argument selects between the three NearMiss variants:
+#'
+#' \describe{
+#'   \item{`version = 1`}{Retains the points from the majority class which
+#'   have the smallest mean distance to their nearest points in the minority
+#'   class.}
+#'   \item{`version = 2`}{Retains the points from the majority class which
+#'   have the smallest mean distance to their farthest points in the minority
+#'   class.}
+#'   \item{`version = 3`}{Works in two stages. First, the `n_neighbors_ver3`
+#'   nearest majority class neighbors of each minority class point form a
+#'   candidate pool, and all other majority class points are removed. Then the
+#'   points of that pool which have the largest mean distance to their nearest
+#'   minority class points are retained.}
+#' }
+#'
+#' Since the size of the NearMiss-3 candidate pool is governed by
+#' `n_neighbors_ver3` rather than by `under_ratio`, the pool can be smaller
+#' than the target set by `under_ratio`. The whole pool is then retained and
+#' the target is not reached.
 #'
 #' With more than two classes, the mean distance is computed to the nearest
 #' points across all other classes, not only the minority class. This differs

--- a/man/nearmiss.Rd
+++ b/man/nearmiss.Rd
@@ -4,7 +4,15 @@
 \alias{nearmiss}
 \title{Remove Points Near Other Classes}
 \usage{
-nearmiss(df, var, k = 5, under_ratio = 1, distance = "euclidean")
+nearmiss(
+  df,
+  var,
+  k = 5,
+  under_ratio = 1,
+  distance = "euclidean",
+  version = 1,
+  n_neighbors_ver3 = 3
+)
 }
 \arguments{
 \item{df}{data.frame or tibble. Must have 1 factor variable and remaining
@@ -50,6 +58,13 @@ individual predictor values.
 The probability divergences are meaningful for compositional predictors such
 as proportions or counts normalized per observation, and are generally not
 appropriate for standardized predictors.}
+
+\item{version}{An integer. Which of the three NearMiss variants to use,
+\code{1}, \code{2}, or \code{3}. Defaults to \code{1}. See the details section.}
+
+\item{n_neighbors_ver3}{An integer. The number of nearest neighbors used
+to build the candidate pool of the NearMiss-3 variant. Only used when
+\code{version = 3}. Defaults to \code{3}.}
 }
 \value{
 A data.frame or tibble, depending on type of \code{df}.
@@ -58,9 +73,26 @@ A data.frame or tibble, depending on type of \code{df}.
 Generates synthetic positive instances using nearmiss algorithm.
 }
 \details{
-This implements the NearMiss-1 algorithm. It retains the points from the
-majority class which have the smallest mean distance to the nearest points
-in the minority class.
+The \code{version} argument selects between the three NearMiss variants:
+
+\describe{
+\item{\code{version = 1}}{Retains the points from the majority class which
+have the smallest mean distance to their nearest points in the minority
+class.}
+\item{\code{version = 2}}{Retains the points from the majority class which
+have the smallest mean distance to their farthest points in the minority
+class.}
+\item{\code{version = 3}}{Works in two stages. First, the \code{n_neighbors_ver3}
+nearest majority class neighbors of each minority class point form a
+candidate pool, and all other majority class points are removed. Then the
+points of that pool which have the largest mean distance to their nearest
+minority class points are retained.}
+}
+
+Since the size of the NearMiss-3 candidate pool is governed by
+\code{n_neighbors_ver3} rather than by \code{under_ratio}, the pool can be smaller
+than the target set by \code{under_ratio}. The whole pool is then retained and
+the target is not reached.
 
 With more than two classes, the mean distance is computed to the nearest
 points across all other classes, not only the minority class. This differs
@@ -79,6 +111,17 @@ res <- nearmiss(circle_numeric, var = "class", k = 10)
 res <- nearmiss(circle_numeric, var = "class", under_ratio = 1.5)
 
 res <- nearmiss(circle_numeric, var = "class", distance = "manhattan")
+
+res <- nearmiss(circle_numeric, var = "class", version = 2)
+
+res <- nearmiss(circle_numeric, var = "class", version = 3)
+
+res <- nearmiss(
+  circle_numeric,
+  var = "class",
+  version = 3,
+  n_neighbors_ver3 = 10
+)
 }
 \references{
 Inderjeet Mani and I Zhang. knn approach to unbalanced data

--- a/man/step_nearmiss.Rd
+++ b/man/step_nearmiss.Rd
@@ -14,6 +14,8 @@ step_nearmiss(
   under_ratio = 1,
   neighbors = 5,
   distance = "euclidean",
+  version = 1,
+  n_neighbors_ver3 = 3,
   skip = TRUE,
   seed = sample.int(10^5, 1),
   distance_with = recipes::all_predictors(),
@@ -78,6 +80,13 @@ The probability divergences are meaningful for compositional predictors such
 as proportions or counts normalized per observation, and are generally not
 appropriate for standardized predictors.}
 
+\item{version}{An integer. Which of the three NearMiss variants to use,
+\code{1}, \code{2}, or \code{3}. Defaults to \code{1}. See the details section.}
+
+\item{n_neighbors_ver3}{An integer. The number of nearest neighbors used
+to build the candidate pool of the NearMiss-3 variant. Only used when
+\code{version = 3}. Defaults to \code{3}.}
+
 \item{skip}{A logical. Should the step be skipped when the recipe is baked by
 \code{\link[recipes:bake]{bake()}}? While all operations are baked when \code{\link[recipes:prep]{prep()}} is run, some
 operations may not be able to be conducted on new data (e.g. processing the
@@ -106,9 +115,26 @@ majority class instances by undersampling points in the majority class based
 on their distance to points in the minority class.
 }
 \details{
-This implements the NearMiss-1 algorithm. It retains the points from the
-majority class which have the smallest mean distance to the nearest points
-in the minority class.
+The \code{version} argument selects between the three NearMiss variants:
+
+\describe{
+\item{\code{version = 1}}{Retains the points from the majority class which
+have the smallest mean distance to their nearest points in the minority
+class.}
+\item{\code{version = 2}}{Retains the points from the majority class which
+have the smallest mean distance to their farthest points in the minority
+class.}
+\item{\code{version = 3}}{Works in two stages. First, the \code{n_neighbors_ver3}
+nearest majority class neighbors of each minority class point form a
+candidate pool, and all other majority class points are removed. Then the
+points of that pool which have the largest mean distance to their nearest
+minority class points are retained.}
+}
+
+Since the size of the NearMiss-3 candidate pool is governed by
+\code{n_neighbors_ver3} rather than by \code{under_ratio}, the pool can be smaller
+than the target set by \code{under_ratio}. The whole pool is then retained and
+the target is not reached.
 
 With more than two classes, the mean distance is computed to the nearest
 points across all other classes, not only the minority class. This differs

--- a/tests/testthat/_snaps/nearmiss.md
+++ b/tests/testthat/_snaps/nearmiss.md
@@ -65,6 +65,42 @@
       Error in `step_nearmiss()`:
       ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
+# printing shows the nearmiss version
+
+    Code
+      step_nearmiss(recipe(class ~ x + y, data = circle_example), class, version = 2)
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:   1
+      predictor: 2
+      
+      -- Operations 
+      * NEARMISS-2 based on: class
+
+---
+
+    Code
+      prep(step_nearmiss(recipe(class ~ x + y, data = circle_example), class,
+      version = 3))
+    Message
+      
+      -- Recipe ----------------------------------------------------------------------
+      
+      -- Inputs 
+      Number of variables by role
+      outcome:   1
+      predictor: 2
+      
+      -- Training information 
+      Training data contained 400 data points and no incomplete rows.
+      
+      -- Operations 
+      * NEARMISS-3 based on: class | Trained
+
 # bad args
 
     Code
@@ -90,6 +126,22 @@
     Condition
       Error in `step_nearmiss()`:
       ! `seed` must be a whole number, not `TRUE`.
+
+---
+
+    Code
+      step_nearmiss(recipe(~., data = mtcars), version = 4)
+    Condition
+      Error in `step_nearmiss()`:
+      ! `version` must be a whole number between 1 and 3, not the number 4.
+
+---
+
+    Code
+      step_nearmiss(recipe(~., data = mtcars), n_neighbors_ver3 = 0)
+    Condition
+      Error in `step_nearmiss()`:
+      ! `n_neighbors_ver3` must be a whole number larger than or equal to 1, not the number 0.
 
 # unused outcome levels are skipped with a warning (#238)
 

--- a/tests/testthat/_snaps/nearmiss_impl.md
+++ b/tests/testthat/_snaps/nearmiss_impl.md
@@ -46,3 +46,46 @@
       Error in `nearmiss()`:
       ! `under_ratio` must be a number, not `TRUE`.
 
+---
+
+    Code
+      nearmiss(circle_example[, c("x", "y", "class")], var = "class", version = 0)
+    Condition
+      Error in `nearmiss()`:
+      ! `version` must be a whole number between 1 and 3, not the number 0.
+
+---
+
+    Code
+      nearmiss(circle_example[, c("x", "y", "class")], var = "class", version = 4)
+    Condition
+      Error in `nearmiss()`:
+      ! `version` must be a whole number between 1 and 3, not the number 4.
+
+---
+
+    Code
+      nearmiss(circle_example[, c("x", "y", "class")], var = "class", version = "2")
+    Condition
+      Error in `nearmiss()`:
+      ! `version` must be a whole number, not the string "2".
+
+---
+
+    Code
+      nearmiss(circle_example[, c("x", "y", "class")], var = "class",
+      n_neighbors_ver3 = TRUE)
+    Condition
+      Error in `nearmiss()`:
+      ! `n_neighbors_ver3` must be a whole number, not `TRUE`.
+
+# nearmiss version 3 errors when n_neighbors_ver3 is too large
+
+    Code
+      nearmiss(df, var = "class", k = 1, version = 3, n_neighbors_ver3 = 5)
+    Condition
+      Error in `nearmiss()`:
+      ! Not enough observations in "maj" to compute 5 nearest neighbors for the NearMiss-3 candidate pool.
+      i 4 observations were found, but 5 are needed.
+      i Lower `n_neighbors_ver3`.
+

--- a/tests/testthat/test-nearmiss.R
+++ b/tests/testthat/test-nearmiss.R
@@ -304,6 +304,38 @@ test_that("bad distance arg for step_nearmiss()", {
   )
 })
 
+test_that("version argument accepted by step_nearmiss()", {
+  for (version in 1:3) {
+    res <- recipe(class ~ x + y, data = circle_example) |>
+      step_nearmiss(class, version = version) |>
+      prep() |>
+      bake(new_data = NULL)
+    expect_gt(nrow(res), 0)
+  }
+})
+
+test_that("n_neighbors_ver3 changes the step_nearmiss() result", {
+  bake_with <- function(n_neighbors_ver3) {
+    recipe(class ~ x + y, data = circle_example) |>
+      step_nearmiss(class, version = 3, n_neighbors_ver3 = n_neighbors_ver3) |>
+      prep() |>
+      bake(new_data = NULL)
+  }
+  expect_gt(nrow(bake_with(10)), nrow(bake_with(3)))
+})
+
+test_that("printing shows the nearmiss version", {
+  expect_snapshot(
+    recipe(class ~ x + y, data = circle_example) |>
+      step_nearmiss(class, version = 2)
+  )
+  expect_snapshot(
+    recipe(class ~ x + y, data = circle_example) |>
+      step_nearmiss(class, version = 3) |>
+      prep()
+  )
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,
@@ -321,6 +353,16 @@ test_that("bad args", {
     error = TRUE,
     recipe(~., data = mtcars) |>
       step_nearmiss(seed = TRUE)
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., data = mtcars) |>
+      step_nearmiss(version = 4)
+  )
+  expect_snapshot(
+    error = TRUE,
+    recipe(~., data = mtcars) |>
+      step_nearmiss(n_neighbors_ver3 = 0)
   )
 })
 

--- a/tests/testthat/test-nearmiss_impl.R
+++ b/tests/testthat/test-nearmiss_impl.R
@@ -72,6 +72,86 @@ test_that("nearmiss keeps the closest rows regardless of row order (#236)", {
   expect_equal(sort(result$x[result$class == "maj"]), c(1, 2))
 })
 
+test_that("nearmiss version 2 uses mean distance to the farthest points", {
+  df <- data.frame(
+    x = c(0, 1, 2, 10, 11),
+    y = rep(0, 5),
+    class = factor(c("maj", "maj", "maj", "min", "min"))
+  )
+  result <- nearmiss(df, var = "class", k = 1, version = 2)
+  # Distance to the farthest minority point (x=11):
+  # x=0: 11, x=1: 10, x=2: 9. under_ratio=1 keeps the 2 smallest → x=1 and x=2
+  expect_equal(sort(result$x[result$class == "maj"]), c(1, 2))
+})
+
+test_that("nearmiss version 3 keeps the farthest points of the candidate pool", {
+  df <- data.frame(
+    x = c(0, 10, 1, 2, 3, 11, 12),
+    y = rep(0, 7),
+    class = factor(c("min", "min", rep("maj", 5)))
+  )
+  result <- nearmiss(
+    df,
+    var = "class",
+    k = 1,
+    version = 3,
+    n_neighbors_ver3 = 1
+  )
+  # Pool = nearest majority point of each minority point → x=1 (for 0) and
+  # x=11 (for 10). Both fit within the target of 2, so both are kept.
+  expect_equal(sort(result$x[result$class == "maj"]), c(1, 11))
+})
+
+test_that("nearmiss version 3 pool grows with n_neighbors_ver3", {
+  circle_numeric <- circle_example[, c("x", "y", "class")]
+  small <- nearmiss(circle_numeric, var = "class", version = 3)
+  large <- nearmiss(
+    circle_numeric,
+    var = "class",
+    version = 3,
+    n_neighbors_ver3 = 10
+  )
+  expect_gt(nrow(large), nrow(small))
+})
+
+test_that("nearmiss versions select different observations", {
+  circle_numeric <- circle_example[, c("x", "y", "class")]
+  res <- lapply(1:3, \(v) {
+    rownames(nearmiss(circle_numeric, "class", version = v))
+  })
+  expect_equal(anyDuplicated(res), 0L)
+})
+
+test_that("nearmiss version 2 reaches the under_ratio target", {
+  circle_numeric <- circle_example[, c("x", "y", "class")]
+  result <- nearmiss(circle_numeric, var = "class", version = 2)
+  expect_equal(
+    unname(table(result$class)[[1]]),
+    unname(table(result$class)[[2]])
+  )
+})
+
+test_that("all distance metrics work for every nearmiss version", {
+  circle_numeric <- circle_example[, c("x", "y", "class")]
+  distances <- c(
+    "euclidean",
+    "cosine",
+    "mahalanobis",
+    "manhattan",
+    "chebyshev"
+  )
+  for (distance in distances) {
+    for (version in 1:3) {
+      expect_no_error(nearmiss(
+        circle_numeric,
+        var = "class",
+        distance = distance,
+        version = version
+      ))
+    }
+  }
+})
+
 test_that("bad args", {
   expect_snapshot(
     error = TRUE,
@@ -92,5 +172,41 @@ test_that("bad args", {
   expect_snapshot(
     error = TRUE,
     nearmiss(circle_example, var = "class", under_ratio = TRUE)
+  )
+  expect_snapshot(
+    error = TRUE,
+    nearmiss(circle_example[, c("x", "y", "class")], var = "class", version = 0)
+  )
+  expect_snapshot(
+    error = TRUE,
+    nearmiss(circle_example[, c("x", "y", "class")], var = "class", version = 4)
+  )
+  expect_snapshot(
+    error = TRUE,
+    nearmiss(
+      circle_example[, c("x", "y", "class")],
+      var = "class",
+      version = "2"
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    nearmiss(
+      circle_example[, c("x", "y", "class")],
+      var = "class",
+      n_neighbors_ver3 = TRUE
+    )
+  )
+})
+
+test_that("nearmiss version 3 errors when n_neighbors_ver3 is too large", {
+  df <- data.frame(
+    x = c(0, 10, 1, 2, 3, 4),
+    y = rep(0, 6),
+    class = factor(c("min", "min", rep("maj", 4)))
+  )
+  expect_snapshot(
+    error = TRUE,
+    nearmiss(df, var = "class", k = 1, version = 3, n_neighbors_ver3 = 5)
   )
 })


### PR DESCRIPTION
`step_nearmiss()` and `nearmiss()` gain a `version` argument selecting between the three NearMiss variants of Mani & Zhang (2003), plus `n_neighbors_ver3` for the size of the NearMiss-3 candidate pool. The default `version = 1` is the behavior that was previously the only option, so nothing changes for existing code.

Two properties are worth knowing when reviewing. NearMiss-3's pool size is governed by `n_neighbors_ver3` rather than `under_ratio`, so it can undershoot the target instead of hitting it exactly (documented rather than worked around, since it is inherent to the algorithm). NearMiss-2 needs the full cross-distance matrix by construction, so it cannot benefit from RANN's k-limited search the way the other variants do. `version` is not tunable, as dials has no matching parameter.

Closes #279