### PR TITLE
Test required_pkgs() for the remaining steps

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@
 ^vignettes/articles$
 ^tests/testthat/testthat-problems\.rds$
 ^codemeta\.json$
+^\.positai$

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ revdep/data.sqlite
 .httr-oauth
 revdep/cloud.noindex/*
 tests/testthat/testthat-problems.rds
+.positai

--- a/R/misc.R
+++ b/R/misc.R
@@ -764,14 +764,6 @@ condense_scan <- function(candidates, in_store, predictors, outcome, distance) {
   list(in_store = in_store, added = added)
 }
 
-weighted_table <- function(x, wts = NULL) {
-  if (is.null(wts)) {
-    wts <- rep(1, length(x))
-  }
-
-  if (!is.factor(x)) {
-    x <- factor(x)
-  }
-
+weighted_table <- function(x, wts) {
   hardhat::weighted_table(x, weights = wts)
 }

--- a/R/smogn_impl.R
+++ b/R/smogn_impl.R
@@ -194,15 +194,6 @@ smogn_relevance <- function(y, relevance = NULL, call = caller_env()) {
       cx <- c(cx, stats[5])
       cy <- c(cy, 1)
     }
-    if (length(cx) < 2) {
-      cli::cli_abort(
-        c(
-          "Unable to determine rare values automatically for the outcome.",
-          i = "Supply relevance control points via the {.arg relevance} argument."
-        ),
-        call = call
-      )
-    }
   } else {
     if (!is.matrix(relevance) || ncol(relevance) < 2) {
       cli::cli_abort(

--- a/R/smoten.R
+++ b/R/smoten.R
@@ -45,7 +45,7 @@
 #'
 #' The Value Difference Metric (VDM) used here deviates from Chawla's stated
 #' form in two ways. The per-feature deltas are aggregated by summing them
-#' (`r = 1`) rather than by taking their Euclidean norm (`r = 2`), and when a
+#' (r = 1) rather than by taking their Euclidean norm (r = 2), and when a
 #' synthetic value is chosen by majority vote of the nearest neighbors the seed
 #' observation itself is excluded from the vote. The metric is internally
 #' consistent and is a valid VDM variant, but be aware of these choices when

--- a/man/step_smoten.Rd
+++ b/man/step_smoten.Rd
@@ -111,7 +111,7 @@ perform the SMOTEN algorithm.
 \section{Value Difference Metric}{
 The Value Difference Metric (VDM) used here deviates from Chawla's stated
 form in two ways. The per-feature deltas are aggregated by summing them
-(\code{r = 1}) rather than by taking their Euclidean norm (\code{r = 2}), and when a
+(r = 1) rather than by taking their Euclidean norm (r = 2), and when a
 synthetic value is chosen by majority vote of the nearest neighbors the seed
 observation itself is excluded from the vote. The metric is internally
 consistent and is a valid VDM variant, but be aware of these choices when
@@ -126,11 +126,14 @@ columns \code{terms} and \code{id}:
 \item{terms}{character, the selectors or variables selected}
 \item{id}{character, id of this step}
 }
+}
 
-\if{html}{\out{<div class="sourceCode {r, echo = FALSE, results="asis"}">}}\preformatted{step <- "step_smoten"
-result <- knitr::knit_child("man/rmd/tunable-args.Rmd")
-cat(result)
-}\if{html}{\out{</div>}}
+\section{Tuning Parameters}{
+This step has 2 tuning parameters:
+\itemize{
+\item \code{over_ratio}: Over-Sampling Ratio (type: double, default: 1)
+\item \code{neighbors}: # Nearest Neighbors (type: integer, default: 5)
+}
 }
 
 \section{Case weights}{

--- a/tests/testthat/_snaps/smogn.md
+++ b/tests/testthat/_snaps/smogn.md
@@ -7,6 +7,45 @@
       Error in `step_smogn()`:
       ! `distance` must be one of "euclidean", "cosine", "mahalanobis", "manhattan", "chebyshev", "squared_chord", "matusita", "hellinger", "bhattacharyya", "canberra", "soergel", "lorentzian", "jeffreys", "topsoe", "jensen-shannon", "jensen_difference", "taneja", or "kumar-johnson", not "L2".
 
+# errors if no rare values are found
+
+    Code
+      prep(step_smogn(recipe(y ~ x, data = circle_example), y, relevance = rel))
+    Condition
+      Error in `step_smogn()`:
+      Caused by error in `bake()`:
+      ! No rare values were found in `y` with the current `threshold`.
+      i Lower `threshold` or supply relevance control points via `relevance`.
+
+# errors if relevance cannot be derived from a constant outcome
+
+    Code
+      prep(step_smogn(recipe(y ~ x, data = df), y))
+    Condition
+      Error in `step_smogn()`:
+      Caused by error in `bake()`:
+      ! Unable to determine rare values automatically for the outcome.
+      i The outcome distribution is degenerate (zero interquartile range or heavily tied values), so relevance control points cannot be derived from its boxplot extremes.
+      i Supply relevance control points via the `relevance` argument.
+
+# errors if relevance is not a two-column matrix
+
+    Code
+      prep(step_smogn(rec, y, relevance = 1:3))
+    Condition
+      Error in `step_smogn()`:
+      Caused by error in `bake()`:
+      ! `relevance` must be a matrix with at least two columns (outcome value and relevance).
+
+---
+
+    Code
+      prep(step_smogn(rec, y, relevance = matrix(1:3, ncol = 1)))
+    Condition
+      Error in `step_smogn()`:
+      Caused by error in `bake()`:
+      ! `relevance` must be a matrix with at least two columns (outcome value and relevance).
+
 # bad data
 
     Code

--- a/tests/testthat/test-S3-methods.R
+++ b/tests/testthat/test-S3-methods.R
@@ -8,6 +8,16 @@ r7 <- r1 |> step_smote(class)
 r8 <- r1 |> step_tomek(class)
 r9 <- r1 |> step_upsample(class)
 r10 <- r1 |> step_instance_hardness(class)
+r11 <- r1 |> step_cluster_centroids(class)
+r12 <- r1 |> step_cnn(class)
+r13 <- r1 |> step_enn(class)
+r14 <- r1 |> step_kmeans_smote(class)
+r15 <- r1 |> step_ncl(class)
+r16 <- r1 |> step_oss(class)
+r17 <- r1 |> step_smogn(x)
+r18 <- r1 |> step_smoten(class)
+r19 <- r1 |> step_smotenc(class)
+r20 <- r1 |> step_svmsmote(class)
 
 # ------------------------------------------------------------------------------
 
@@ -21,6 +31,16 @@ test_that("required packages", {
   expect_equal(required_pkgs(r8), c("recipes", "themis"))
   expect_equal(required_pkgs(r9), c("recipes", "themis"))
   expect_equal(required_pkgs(r10), c("recipes", "themis"))
+  expect_equal(required_pkgs(r11), c("recipes", "themis"))
+  expect_equal(required_pkgs(r12), c("recipes", "themis"))
+  expect_equal(required_pkgs(r13), c("recipes", "themis"))
+  expect_equal(required_pkgs(r14), c("recipes", "themis"))
+  expect_equal(required_pkgs(r15), c("recipes", "themis"))
+  expect_equal(required_pkgs(r16), c("recipes", "themis"))
+  expect_equal(required_pkgs(r17), c("recipes", "themis"))
+  expect_equal(required_pkgs(r18), c("recipes", "themis"))
+  expect_equal(required_pkgs(r19), c("recipes", "themis"))
+  expect_equal(required_pkgs(r20), c("recipes", "themis", "kernlab"))
 })
 
 test_that("tunable arguments", {

--- a/tests/testthat/test-smogn.R
+++ b/tests/testthat/test-smogn.R
@@ -64,6 +64,46 @@ test_that("custom relevance control points are respected", {
   )
 })
 
+test_that("errors if no rare values are found", {
+  rel <- cbind(range(circle_example$y), c(0, 0))
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(y ~ x, data = circle_example) |>
+      step_smogn(y, relevance = rel) |>
+      prep()
+  )
+})
+
+test_that("errors if relevance cannot be derived from a constant outcome", {
+  df <- circle_example[, c("x", "y")]
+  df$y <- 5
+
+  expect_snapshot(
+    error = TRUE,
+    recipe(y ~ x, data = df) |>
+      step_smogn(y) |>
+      prep()
+  )
+})
+
+test_that("errors if relevance is not a two-column matrix", {
+  rec <- recipe(y ~ x, data = circle_example)
+
+  expect_snapshot(
+    error = TRUE,
+    rec |>
+      step_smogn(y, relevance = 1:3) |>
+      prep()
+  )
+  expect_snapshot(
+    error = TRUE,
+    rec |>
+      step_smogn(y, relevance = matrix(1:3, ncol = 1)) |>
+      prep()
+  )
+})
+
 test_that("`seed` produces identical sampling", {
   step_with_seed <- function(seed = sample.int(10^5, 1)) {
     recipe(y ~ x, data = circle_example) |>

--- a/tests/testthat/test-upsample.R
+++ b/tests/testthat/test-upsample.R
@@ -323,6 +323,27 @@ test_that("NA values in outcome are handled", {
   )
 })
 
+test_that("indicator_column marks new rows when the outcome has NA", {
+  df <- data.frame(
+    x = 1:10,
+    class = factor(c(NA, "A", "A", "A", "A", "B", "B", "B", "B", "B"))
+  )
+
+  result <- recipe(~., data = df) |>
+    step_upsample(class, indicator_column = ".new_row", seed = 1) |>
+    prep() |>
+    bake(new_data = NULL)
+
+  expect_equal(sum(!result$.new_row), nrow(df))
+  expect_equal(
+    result[!result$.new_row, c("x", "class")],
+    tibble::as_tibble(df[order(df$class), ]),
+    ignore_attr = TRUE
+  )
+  # the NA group is upsampled towards the shared target like any other class
+  expect_equal(sum(is.na(result$class)), 5L)
+})
+
 test_that("unused outcome levels are skipped with a warning (#238)", {
   circle_example$class <- factor(
     circle_example$class,


### PR DESCRIPTION
Ten of the `required_pkgs.step_*()` methods had no test coverage, so this extends the existing "required packages" test in `test-S3-methods.R` to cover all of them. Also picks up two bits of housekeeping that were sitting in my working tree: regenerated `man/step_smoten.Rd` (the tunable-args child chunk hadn't been knit) and a `.positai` ignore entry.